### PR TITLE
Issue 12 tree generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -277,20 +277,20 @@ files = [
 
 [[package]]
 name = "networkx"
-version = "3.0"
+version = "3.1"
 description = "Python package for creating and manipulating graphs and networks"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "networkx-3.0-py3-none-any.whl", hash = "sha256:58058d66b1818043527244fab9d41a51fcd7dcc271748015f3c181b8a90c8e2e"},
-    {file = "networkx-3.0.tar.gz", hash = "sha256:9a9992345353618ae98339c2b63d8201c381c2944f38a2ab49cb45a4c667e412"},
+    {file = "networkx-3.1-py3-none-any.whl", hash = "sha256:4f33f68cb2afcf86f28a45f43efc27a9386b535d567d2127f8f61d51dec58d36"},
+    {file = "networkx-3.1.tar.gz", hash = "sha256:de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61"},
 ]
 
 [package.extras]
 default = ["matplotlib (>=3.4)", "numpy (>=1.20)", "pandas (>=1.3)", "scipy (>=1.8)"]
-developer = ["mypy (>=0.991)", "pre-commit (>=2.20)"]
-doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.2)", "pydata-sphinx-theme (>=0.11)", "sphinx (==5.2.3)", "sphinx-gallery (>=0.11)", "texext (>=0.6.7)"]
+developer = ["mypy (>=1.1)", "pre-commit (>=3.2)"]
+doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.13)", "sphinx (>=6.1)", "sphinx-gallery (>=0.12)", "texext (>=0.6.7)"]
 extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.10)", "sympy (>=1.10)"]
 test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
@@ -511,7 +511,7 @@ files = [
 
 [[package]]
 name = "spdx-tools"
-version = "0.7.2.dev374+g8da3a321"
+version = "0.7.2.dev380+g0e1df0ac"
 description = "SPDX parser and tools."
 category = "main"
 optional = false
@@ -537,7 +537,7 @@ test = ["pytest"]
 type = "git"
 url = "https://github.com/spdx/tools-python.git"
 reference = "main"
-resolved_reference = "8da3a321a1cdb93329299534eb0f80bcb0b9f0f4"
+resolved_reference = "91bb7442ed41f59ca0a01d00bf28f5d3cbb5869c"
 
 [[package]]
 name = "tomli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,11 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
+[[tool.mypy.overrides]]
+module = [
+    'networkx.*'
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -11,11 +11,18 @@ from spdx.model.relationship import Relationship
 
 def generate_graph_from_spdx(document: Document) -> DiGraph:
     graph = DiGraph()
-    graph.add_node(document.creation_info.spdx_id, element=document.creation_info)
+    graph.add_node(
+        document.creation_info.spdx_id,
+        element=document.creation_info,
+        label=document.creation_info.spdx_id,
+    )
 
     contained_elements: List[str] = get_contained_spdx_element_ids(document)
     contained_element_nodes = [
-        (spdx_id, {"element": get_element_from_spdx_id(document, spdx_id)})
+        (
+            spdx_id,
+            {"element": get_element_from_spdx_id(document, spdx_id), "label": spdx_id},
+        )
         for spdx_id in contained_elements
     ]
     graph.add_nodes_from(contained_element_nodes)
@@ -26,12 +33,20 @@ def generate_graph_from_spdx(document: Document) -> DiGraph:
 
     for spdx_id, relationships in relationships_by_spdx_id.items():
         if spdx_id not in graph.nodes():
-            graph.add_node(spdx_id, element=get_element_from_spdx_id(document, spdx_id))
+            graph.add_node(
+                spdx_id,
+                element=get_element_from_spdx_id(document, spdx_id),
+                label=spdx_id,
+            )
         for relationship in relationships:
             relationship_node_key = (
                 relationship.spdx_element_id + "_" + relationship.relationship_type.name
             )
-            graph.add_node(relationship_node_key, comment=relationship.comment)
+            graph.add_node(
+                relationship_node_key,
+                comment=relationship.comment,
+                label=relationship.relationship_type.name,
+            )
             graph.add_edge(relationship.spdx_element_id, relationship_node_key)
             # if the related spdx element is SpdxNone or SpdxNoAssertion we need a
             # type conversion
@@ -41,6 +56,7 @@ def generate_graph_from_spdx(document: Document) -> DiGraph:
                 graph.add_node(
                     related_spdx_element_id,
                     element=get_element_from_spdx_id(document, spdx_id),
+                    label=related_spdx_element_id,
                 )
             graph.add_edge(relationship_node_key, related_spdx_element_id)
 

--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List
 
-from networkx import DiGraph  # type: ignore
+from networkx import DiGraph
 from spdx.document_utils import get_contained_spdx_element_ids, get_element_from_spdx_id
 from spdx.model.document import Document
 from spdx.model.relationship import Relationship

--- a/src/opossum_lib/tree_generation.py
+++ b/src/opossum_lib/tree_generation.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict, Optional, Tuple, Union
+
+from mypy.copytype import Any
+from networkx import (
+    DiGraph,
+    edge_bfs,
+    is_weakly_connected,
+    subgraph,
+    weakly_connected_components,
+)
+from spdx.model.document import CreationInfo
+from spdx.model.file import File
+from spdx.model.package import Package
+
+
+def generate_tree_from_graph(
+    graph: DiGraph,
+    source: Optional[str] = "SPDXRef-DOCUMENT",
+    tree: Optional[DiGraph] = None,
+) -> DiGraph:
+    if not graph.edges():
+        return graph
+
+    if is_weakly_connected(graph):
+        tree = tree or DiGraph()
+        edges_bfs = edge_bfs(graph, source)
+        visited_edges = []
+        for edge in edges_bfs:
+            _add_source_node(edge, graph, tree)
+            _add_target_node_and_edge(edge, graph, tree)
+            visited_edges += [edge]
+        # check if there is a directed path from source to each element node
+        # if not, we need to construct sub-graphs from the unreached edges
+        # and construct trees for all of these sub-graphs, the result
+        # will be an unconnected graph
+        unreached_edges = set(graph.edges).difference(set(visited_edges))
+        if unreached_edges:
+            induced_subgraph = graph.edge_subgraph(unreached_edges)
+            source = _get_node_without_incoming_edge(induced_subgraph)
+            tree_component = generate_tree_from_graph(induced_subgraph, source, tree)
+            tree.add_nodes_from(tree_component.nodes)
+            tree.add_edges_from(tree_component.edges)
+
+    else:  # get connected components
+        tree = DiGraph()
+        for connected_set in weakly_connected_components(
+            graph
+        ):  # returns only a set of nodes without edges
+            connected_subgraph = subgraph(graph, connected_set)
+            # if the documents node is not in the subgraph we choose
+            # any elements node without incoming edge
+            source = (
+                "SPDXRef-DOCUMENT"
+                if "SPDXRef-DOCUMENT" in connected_set
+                else _get_node_without_incoming_edge(connected_subgraph)
+            )
+            tree_component = generate_tree_from_graph(connected_subgraph, source)
+            tree.add_nodes_from(tree_component.nodes)
+            tree.add_edges_from(tree_component.edges)
+
+    return tree
+
+
+def _add_target_node_and_edge(
+    edge: Tuple[str, str], graph: DiGraph, tree: DiGraph
+) -> None:
+    if edge[1] not in tree:
+        target_node_data = graph.nodes[edge[1]]
+        tree.add_node(edge[1], **target_node_data)
+        tree.add_edge(*edge)
+    else:
+        # if the child node is already in the graph duplicate the node by adding the
+        # parent node as prefix
+        target_node_data = graph.nodes[edge[1]]
+        duplicated_node = edge[0] + "_" + edge[1]
+        tree.add_node(duplicated_node, **target_node_data)
+        tree.add_edge(edge[0], duplicated_node)
+
+
+def _add_source_node(edge: Tuple[str, str], graph: DiGraph, tree: DiGraph) -> None:
+    if edge[0] not in tree:
+        source_node_data: Dict[str, Union[CreationInfo, Package, File]] = graph.nodes[
+            edge[0]
+        ]
+        tree.add_node(edge[0], **source_node_data)
+
+
+def _get_node_without_incoming_edge(graph: DiGraph) -> Any:
+    for node, degree in graph.in_degree():
+        if degree == 0 and "element" in graph.nodes[node]:
+            return node
+    return ""

--- a/src/opossum_lib/tree_generation.py
+++ b/src/opossum_lib/tree_generation.py
@@ -1,16 +1,9 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
-from mypy.copytype import Any
-from networkx import (
-    DiGraph,
-    edge_bfs,
-    is_weakly_connected,
-    subgraph,
-    weakly_connected_components,
-)
+from networkx import DiGraph, edge_bfs, is_weakly_connected, weakly_connected_components
 from spdx.model.document import CreationInfo
 from spdx.model.file import File
 from spdx.model.package import Package
@@ -41,15 +34,15 @@ def generate_tree_from_graph(
             induced_subgraph = graph.edge_subgraph(unreached_edges)
             source = _get_node_without_incoming_edge(induced_subgraph)
             tree_component = generate_tree_from_graph(induced_subgraph, source, tree)
-            tree.add_nodes_from(tree_component.nodes)
-            tree.add_edges_from(tree_component.edges)
+            tree.add_nodes_from(tree_component.nodes(data=True))
+            tree.add_edges_from(tree_component.edges(data=True))
 
     else:  # get connected components
         tree = DiGraph()
         for connected_set in weakly_connected_components(
             graph
         ):  # returns only a set of nodes without edges
-            connected_subgraph = subgraph(graph, connected_set)
+            connected_subgraph = graph.subgraph(connected_set).copy()
             # if the documents node is not in the subgraph we choose
             # any elements node without incoming edge
             source = (
@@ -58,8 +51,8 @@ def generate_tree_from_graph(
                 else _get_node_without_incoming_edge(connected_subgraph)
             )
             tree_component = generate_tree_from_graph(connected_subgraph, source)
-            tree.add_nodes_from(tree_component.nodes)
-            tree.add_edges_from(tree_component.edges)
+            tree.add_nodes_from(tree_component.nodes(data=True))
+            tree.add_edges_from(tree_component.edges(data=True))
 
     return tree
 

--- a/tests/helper_methods.py
+++ b/tests/helper_methods.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+
+from spdx.model.actor import Actor, ActorType
+from spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx.model.document import CreationInfo, Document
+from spdx.model.file import File
+from spdx.model.package import Package
+from spdx.model.relationship import Relationship, RelationshipType
+
+
+def _create_minimal_document() -> Document:
+    # this is a helper method to create a minimal document that describes two
+    # packages which both contain the same file
+    creation_info = CreationInfo(
+        spdx_version="SPDX-2.3",
+        spdx_id="SPDXRef-DOCUMENT",
+        data_license="CC0-1.0",
+        name="SPDX Lite Document",
+        document_namespace="https://test.namespace.com",
+        creators=[Actor(ActorType.PERSON, "Meret Behrens")],
+        created=datetime(2023, 3, 14, 8, 49),
+    )
+    package_a = Package(
+        name="Example package A",
+        spdx_id="SPDXRef-Package-A",
+        download_location="https://download.com",
+    )
+    package_b = Package(
+        name="Example package B",
+        spdx_id="SPDXRef-Package-B",
+        download_location="https://download.com",
+    )
+    file = File(
+        name="Example file",
+        spdx_id="SPDXRef-File",
+        checksums=[Checksum(ChecksumAlgorithm.SHA1, "")],
+    )
+
+    relationships = [
+        Relationship(
+            "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package-A"
+        ),
+        Relationship(
+            "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package-B"
+        ),
+        Relationship("SPDXRef-Package-A", RelationshipType.CONTAINS, "SPDXRef-File"),
+        Relationship("SPDXRef-Package-B", RelationshipType.CONTAINS, "SPDXRef-File"),
+    ]
+    document = Document(
+        creation_info=creation_info,
+        packages=[package_a, package_b],
+        files=[file],
+        relationships=relationships,
+    )
+
+    return document

--- a/tests/test_graph_generation.py
+++ b/tests/test_graph_generation.py
@@ -1,22 +1,17 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
 from pathlib import Path
 from typing import List
 from unittest import TestCase
 
 import pytest
-from spdx.model.actor import Actor, ActorType
-from spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx.model.document import CreationInfo, Document
-from spdx.model.file import File
 from spdx.model.package import Package
-from spdx.model.relationship import Relationship, RelationshipType
 from spdx.parser.parse_anything import parse_file
 from spdx.validation.document_validator import validate_full_spdx_document
 
 from opossum_lib.graph_generation import generate_graph_from_spdx
+from tests.helper_methods import _create_minimal_document
 
 
 @pytest.mark.parametrize(
@@ -120,51 +115,3 @@ def test_complete_unconnected_graph() -> None:
             ("SPDXRef-Package-B_CONTAINS", "SPDXRef-File"),
         ],
     )
-
-
-def _create_minimal_document() -> Document:
-    # this is a helper method to create a minimal document that describes two
-    # packages which both contain the same file
-    creation_info = CreationInfo(
-        spdx_version="SPDX-2.3",
-        spdx_id="SPDXRef-DOCUMENT",
-        data_license="CC0-1.0",
-        name="SPDX Lite Document",
-        document_namespace="https://test.namespace.com",
-        creators=[Actor(ActorType.PERSON, "Meret Behrens")],
-        created=datetime(2023, 3, 14, 8, 49),
-    )
-    package_a = Package(
-        name="Example package A",
-        spdx_id="SPDXRef-Package-A",
-        download_location="https://download.com",
-    )
-    package_b = Package(
-        name="Example package B",
-        spdx_id="SPDXRef-Package-B",
-        download_location="https://download.com",
-    )
-    file = File(
-        name="Example file",
-        spdx_id="SPDXRef-File",
-        checksums=[Checksum(ChecksumAlgorithm.SHA1, "")],
-    )
-
-    relationships = [
-        Relationship(
-            "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package-A"
-        ),
-        Relationship(
-            "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package-B"
-        ),
-        Relationship("SPDXRef-Package-A", RelationshipType.CONTAINS, "SPDXRef-File"),
-        Relationship("SPDXRef-Package-B", RelationshipType.CONTAINS, "SPDXRef-File"),
-    ]
-    document = Document(
-        creation_info=creation_info,
-        packages=[package_a, package_b],
-        files=[file],
-        relationships=relationships,
-    )
-
-    return document

--- a/tests/test_tree_generation.py
+++ b/tests/test_tree_generation.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+from pathlib import Path
+from typing import List
+from unittest import TestCase
+
+import pytest
+from networkx import is_weakly_connected
+from spdx.model.actor import Actor, ActorType
+from spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx.model.document import CreationInfo, Document
+from spdx.model.file import File
+from spdx.model.package import Package
+from spdx.model.relationship import Relationship, RelationshipType
+from spdx.parser.parse_anything import parse_file
+
+from opossum_lib.graph_generation import generate_graph_from_spdx
+from opossum_lib.tree_generation import generate_tree_from_graph
+from tests.helper_methods import _create_minimal_document
+
+
+def test_different_paths_graph() -> None:
+    # generate tree from a directed graph with a cycle
+    document = _create_minimal_document()
+
+    graph = generate_graph_from_spdx(document)
+    tree = generate_tree_from_graph(graph)
+
+    TestCase().assertCountEqual(
+        tree.nodes(),
+        [
+            "SPDXRef-DOCUMENT",
+            "SPDXRef-Package-A",
+            "SPDXRef-Package-B",
+            "SPDXRef-File",
+            "SPDXRef-DOCUMENT_DESCRIBES",
+            "SPDXRef-Package-A_CONTAINS",
+            "SPDXRef-Package-B_CONTAINS",
+            "SPDXRef-Package-B_CONTAINS_SPDXRef-File",
+        ],
+    )
+    TestCase().assertCountEqual(
+        tree.edges(),
+        [
+            ("SPDXRef-DOCUMENT", "SPDXRef-DOCUMENT_DESCRIBES"),
+            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-A"),
+            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-B"),
+            ("SPDXRef-Package-A", "SPDXRef-Package-A_CONTAINS"),
+            ("SPDXRef-Package-A_CONTAINS", "SPDXRef-File"),
+            ("SPDXRef-Package-B", "SPDXRef-Package-B_CONTAINS"),
+            ("SPDXRef-Package-B_CONTAINS", "SPDXRef-Package-B_CONTAINS_SPDXRef-File"),
+        ],
+    )
+
+
+def test_unconnected_graph() -> None:
+    # test tree creation for an unconnected graph
+    document = _create_minimal_document()
+    document.packages += [
+        Package(
+            spdx_id="SPDXRef-Package-C",
+            name="Package without connection to document",
+            download_location="https://download.location.com",
+        )
+    ]
+
+    graph = generate_graph_from_spdx(document)
+    tree = generate_tree_from_graph(graph)
+
+    TestCase().assertCountEqual(
+        tree.nodes(),
+        [
+            "SPDXRef-DOCUMENT",
+            "SPDXRef-Package-A",
+            "SPDXRef-Package-B",
+            "SPDXRef-File",
+            "SPDXRef-DOCUMENT_DESCRIBES",
+            "SPDXRef-Package-A_CONTAINS",
+            "SPDXRef-Package-B_CONTAINS",
+            "SPDXRef-Package-B_CONTAINS_SPDXRef-File",
+            "SPDXRef-Package-C",
+        ],
+    )
+    TestCase().assertCountEqual(
+        tree.edges(),
+        [
+            ("SPDXRef-DOCUMENT", "SPDXRef-DOCUMENT_DESCRIBES"),
+            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-A"),
+            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-B"),
+            ("SPDXRef-Package-A", "SPDXRef-Package-A_CONTAINS"),
+            ("SPDXRef-Package-A_CONTAINS", "SPDXRef-File"),
+            ("SPDXRef-Package-B", "SPDXRef-Package-B_CONTAINS"),
+            ("SPDXRef-Package-B_CONTAINS", "SPDXRef-Package-B_CONTAINS_SPDXRef-File"),
+        ],
+    )
+
+
+def test_different_roots_graph() -> None:
+    # test tree generation for a connected graph where some edges are not reachable
+    # from the SPDXRef-DOCUMENT node that means the connected graph has multiple sources
+    # and the result should be disconnected
+    download_location = "https"
+    packages = [
+        Package(
+            spdx_id="SPDXRef-Package-A",
+            name="Package-A",
+            download_location=download_location,
+        ),
+        Package(
+            spdx_id="SPDXRef-Package-B",
+            name="Package-B",
+            download_location=download_location,
+        ),
+    ]
+    checksum = Checksum(ChecksumAlgorithm.SHA1, "")
+    files = [
+        File(spdx_id="SPDXRef-File-A", checksums=[checksum], name="File-A"),
+        File(spdx_id="SPDXRef-File-B", checksums=[checksum], name="File-B"),
+    ]
+
+    relationships = [
+        Relationship("SPDXRef-Package-A", RelationshipType.CONTAINS, "SPDXRef-File-A"),
+        Relationship(
+            "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package-A"
+        ),
+        Relationship(
+            "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package-B"
+        ),
+        Relationship("SPDXRef-File-B", RelationshipType.DESCRIBES, "SPDXRef-Package-B"),
+    ]
+    document = Document(
+        creation_info=CreationInfo(
+            spdx_id="SPDXRef-DOCUMENT",
+            spdx_version="SPDX-2.3",
+            name="Document",
+            document_namespace="https",
+            created=datetime(2022, 2, 2),
+            creators=[Actor(ActorType.PERSON, "Me")],
+        ),
+        files=files,
+        relationships=relationships,
+        packages=packages,
+    )
+
+    graph = generate_graph_from_spdx(document)
+    tree = generate_tree_from_graph(graph)
+
+    TestCase().assertCountEqual(
+        tree.nodes(),
+        [
+            "SPDXRef-DOCUMENT",
+            "SPDXRef-Package-A",
+            "SPDXRef-Package-B",
+            "SPDXRef-File-A",
+            "SPDXRef-File-B",
+            "SPDXRef-DOCUMENT_DESCRIBES",
+            "SPDXRef-Package-A_CONTAINS",
+            "SPDXRef-File-B_DESCRIBES",
+            "SPDXRef-File-B_DESCRIBES_SPDXRef-Package-B",
+        ],
+    )
+    TestCase().assertCountEqual(
+        tree.edges(),
+        [
+            ("SPDXRef-DOCUMENT", "SPDXRef-DOCUMENT_DESCRIBES"),
+            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-A"),
+            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-B"),
+            ("SPDXRef-Package-A", "SPDXRef-Package-A_CONTAINS"),
+            ("SPDXRef-Package-A_CONTAINS", "SPDXRef-File-A"),
+            ("SPDXRef-File-B", "SPDXRef-File-B_DESCRIBES"),
+            ("SPDXRef-File-B_DESCRIBES", "SPDXRef-File-B_DESCRIBES_SPDXRef-Package-B"),
+        ],
+    )
+
+    assert is_weakly_connected(graph)
+    assert not is_weakly_connected(tree)
+
+
+@pytest.mark.parametrize(
+    "file_name, nodes_count, edges_count, relationship_node_keys",
+    [
+        (
+            "SPDXJSONExample-v2.3.spdx.json",
+            25,
+            22,
+            ["SPDXRef-Package_DYNAMIC_LINK", "SPDXRef-JenaLib_CONTAINS"],
+        ),
+        ("SPDX.spdx", 12, 10, []),
+    ],
+)
+def test_tree_generation_for_bigger_examples(
+    file_name: str,
+    nodes_count: int,
+    edges_count: int,
+    relationship_node_keys: List[str],
+) -> None:
+    document = parse_file(str(Path(__file__).resolve().parent / "data" / file_name))
+    graph = generate_graph_from_spdx(document)
+    tree = generate_tree_from_graph(graph)
+
+    assert document.creation_info.spdx_id in tree.nodes()
+    assert tree.number_of_nodes() == nodes_count
+    assert tree.number_of_nodes() >= graph.number_of_nodes()
+    assert tree.number_of_edges() == edges_count
+    assert tree.number_of_edges() >= graph.number_of_edges()


### PR DESCRIPTION
This PR adds some logic to generate a tree from a given graph. The tests handle three main cases:
- generation of a tree for a graph that contains an undirected cycle
- generation of a tree for a graph that has two components
- generation of a tree for a connected graph where there is not a directed path for each node from the root node of the document. In this case we duplicated the node which "connects" these unreachable nodes with root node and get two trees that are not connected as in the picture below. 
![image](https://user-images.githubusercontent.com/50019307/229101316-6fb2ebd0-ef90-4456-a203-bfd5dade99f6.png)

fixes #12