### PR TITLE
[issue_13] add breakpoints for nodes that represent a relationship

### DIFF
--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -83,10 +83,10 @@ def get_breakpoints(graph: DiGraph, source: str) -> List[str]:
     for node in graph.nodes():
         if not _node_represents_a_spdx_element(graph, node):
             path = shortest_path(graph, source, node)
-            breakpoints.append(_create_file_path_from_graph_path(path))
+            breakpoints.append(_create_file_path_from_graph_path(graph, path))
 
     return breakpoints
 
 
-def _create_file_path_from_graph_path(path: List[str]) -> str:
-    return "/" + "/".join(path) + "/"
+def _create_file_path_from_graph_path(graph: DiGraph, path: List[str]) -> str:
+    return "/" + "/".join([graph.nodes[node]["label"] for node in path]) + "/"

--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -13,16 +13,13 @@ from opossum_lib.helper_methods import (
     _node_represents_a_spdx_element,
 )
 
-OpossumInformation = TypedDict(
-    "OpossumInformation",
-    {
-        "metadata": Dict[str, str],
-        "resources": Dict[str, Any],
-        "externalAttributions": Dict,
-        "resourcesToAttributions": Dict,
-        "attributionBreakpoints": List[str],
-    },
-)
+
+class OpossumInformation(TypedDict):
+    metadata: Dict[str, str]
+    resources: Dict[str, Any]
+    externalAttributions: Dict
+    resourcesToAttributions: Dict
+    attributionBreakpoints: List[str]
 
 
 def write_dict_to_file(
@@ -67,23 +64,23 @@ def generate_json_file_from_tree(
     return opossum_information
 
 
-def tree_to_dict(graph: DiGraph, source: str) -> Union[int, Dict[str, Any]]:
-    successors = list(graph.successors(source))
+def tree_to_dict(tree: DiGraph, source: str) -> Union[int, Dict[str, Any]]:
+    successors = list(tree.successors(source))
     if not successors:
         return 1
     branch_dict = {}
     for successor in successors:
-        successor_name = graph.nodes[successor]["label"]
-        branch_dict[successor_name] = tree_to_dict(graph, successor)
+        successor_name = tree.nodes[successor]["label"]
+        branch_dict[successor_name] = tree_to_dict(tree, successor)
     return branch_dict
 
 
-def get_breakpoints(graph: DiGraph, source: str) -> List[str]:
+def get_breakpoints(tree: DiGraph, source: str) -> List[str]:
     breakpoints = []
-    for node in graph.nodes():
-        if not _node_represents_a_spdx_element(graph, node):
-            path = shortest_path(graph, source, node)
-            breakpoints.append(_create_file_path_from_graph_path(graph, path))
+    for node in tree.nodes():
+        if not _node_represents_a_spdx_element(tree, node):
+            path = shortest_path(tree, source, node)
+            breakpoints.append(_create_file_path_from_graph_path(tree, path))
 
     return breakpoints
 

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 from unittest import TestCase
 
 import pytest
@@ -36,11 +36,27 @@ def test_different_paths_graph() -> None:
     opossum_information = generate_json_file_from_tree(tree)
 
     TestCase().assertCountEqual(
-        ["metadata", "resources", "externalAttributions", "resourcesToAttributions"],
+        [
+            "metadata",
+            "resources",
+            "externalAttributions",
+            "resourcesToAttributions",
+            "attributionBreakpoints",
+        ],
         list(opossum_information.keys()),
     )
     file_tree = opossum_information["resources"]
     assert file_tree == expected_file_tree
+    TestCase().assertCountEqual(
+        opossum_information["attributionBreakpoints"],
+        [
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/",
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
+            "SPDXRef-Package-A_CONTAINS/",
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-B/"
+            "SPDXRef-Package-B_CONTAINS/",
+        ],
+    )
 
 
 def test_unconnected_paths_graph() -> None:
@@ -69,11 +85,27 @@ def test_unconnected_paths_graph() -> None:
     opossum_information = generate_json_file_from_tree(tree)
 
     TestCase().assertCountEqual(
-        ["metadata", "resources", "externalAttributions", "resourcesToAttributions"],
+        [
+            "metadata",
+            "resources",
+            "externalAttributions",
+            "resourcesToAttributions",
+            "attributionBreakpoints",
+        ],
         list(opossum_information.keys()),
     )
     file_tree = opossum_information["resources"]
     assert file_tree == expected_file_tree
+    TestCase().assertCountEqual(
+        opossum_information["attributionBreakpoints"],
+        [
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/",
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
+            "SPDXRef-Package-A_CONTAINS/",
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-B/"
+            "SPDXRef-Package-B_CONTAINS/",
+        ],
+    )
 
 
 def test_different_roots_graph() -> None:
@@ -96,16 +128,31 @@ def test_different_roots_graph() -> None:
     opossum_information = generate_json_file_from_tree(tree)
 
     TestCase().assertCountEqual(
-        ["metadata", "resources", "externalAttributions", "resourcesToAttributions"],
+        [
+            "metadata",
+            "resources",
+            "externalAttributions",
+            "resourcesToAttributions",
+            "attributionBreakpoints",
+        ],
         list(opossum_information.keys()),
     )
     file_tree = opossum_information["resources"]
     assert file_tree == expected_file_tree
+    TestCase().assertCountEqual(
+        opossum_information["attributionBreakpoints"],
+        [
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/",
+            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
+            "SPDXRef-Package-A_CONTAINS/",
+            "/SPDXRef-File-B/SPDXRef-File-B_DESCRIBES/",
+        ],
+    )
 
 
 @pytest.mark.parametrize(
     "file_name, expected_top_level_keys, expected_file_path_level_1, "
-    "expected_file_path_level_2",
+    "expected_file_path_level_2, expected_breakpoints",
     [
         (
             "SPDXJSONExample-v2.3.spdx.json",
@@ -122,6 +169,13 @@ def test_different_roots_graph() -> None:
                 "DYNAMIC_LINK",
                 "SPDXRef-Saxon",
             ),
+            [
+                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_CONTAINS/SPDXRef-Package/"
+                "SPDXRef-Package_CONTAINS/"
+                "SPDXRef-CommonsLangSrc/SPDXRef-CommonsLangSrc_GENERATED_FROM/",
+                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_CONTAINS/SPDXRef-Package/"
+                "SPDXRef-Package_DYNAMIC_LINK/",
+            ],
         ),
         (
             "SPDX.spdx",
@@ -134,6 +188,13 @@ def test_different_roots_graph() -> None:
                 "CONTAINS",
                 "SPDXRef-File-C",
             ),
+            [
+                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
+                "SPDXRef-Package-A_CONTAINS/",
+                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
+                "SPDXRef-Package-A_COPY_OF/"
+                "SPDXRef-Package-C/SPDXRef-Package-C_CONTAINS/",
+            ],
         ),
     ],
 )
@@ -142,6 +203,7 @@ def test_tree_generation_for_bigger_examples(
     expected_top_level_keys: int,
     expected_file_path_level_1: Tuple[str, str, str],
     expected_file_path_level_2: Tuple[str, str, str, str, str],
+    expected_breakpoints: List[str],
 ) -> None:
     document = parse_file(str(Path(__file__).resolve().parent / "data" / file_name))
     graph = generate_graph_from_spdx(document)
@@ -149,7 +211,13 @@ def test_tree_generation_for_bigger_examples(
     opossum_information = generate_json_file_from_tree(tree)
 
     TestCase().assertCountEqual(
-        ["metadata", "resources", "externalAttributions", "resourcesToAttributions"],
+        [
+            "metadata",
+            "resources",
+            "externalAttributions",
+            "resourcesToAttributions",
+            "attributionBreakpoints",
+        ],
         list(opossum_information.keys()),
     )
     file_tree = opossum_information["resources"]
@@ -166,3 +234,6 @@ def test_tree_generation_for_bigger_examples(
         ][expected_file_path_level_2[3]][expected_file_path_level_2[4]]
         == 1
     )
+
+    for attribution_breakpoint in expected_breakpoints:
+        assert attribution_breakpoint in opossum_information["attributionBreakpoints"]

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -50,11 +50,9 @@ def test_different_paths_graph() -> None:
     TestCase().assertCountEqual(
         opossum_information["attributionBreakpoints"],
         [
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/",
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
-            "SPDXRef-Package-A_CONTAINS/",
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-B/"
-            "SPDXRef-Package-B_CONTAINS/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-A/CONTAINS/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-B/CONTAINS/",
         ],
     )
 
@@ -99,11 +97,9 @@ def test_unconnected_paths_graph() -> None:
     TestCase().assertCountEqual(
         opossum_information["attributionBreakpoints"],
         [
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/",
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
-            "SPDXRef-Package-A_CONTAINS/",
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-B/"
-            "SPDXRef-Package-B_CONTAINS/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-A/CONTAINS/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-B/CONTAINS/",
         ],
     )
 
@@ -142,10 +138,9 @@ def test_different_roots_graph() -> None:
     TestCase().assertCountEqual(
         opossum_information["attributionBreakpoints"],
         [
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/",
-            "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
-            "SPDXRef-Package-A_CONTAINS/",
-            "/SPDXRef-File-B/SPDXRef-File-B_DESCRIBES/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/",
+            "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-A/CONTAINS/",
+            "/SPDXRef-File-B/DESCRIBES/",
         ],
     )
 
@@ -170,11 +165,9 @@ def test_different_roots_graph() -> None:
                 "SPDXRef-Saxon",
             ),
             [
-                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_CONTAINS/SPDXRef-Package/"
-                "SPDXRef-Package_CONTAINS/"
-                "SPDXRef-CommonsLangSrc/SPDXRef-CommonsLangSrc_GENERATED_FROM/",
-                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_CONTAINS/SPDXRef-Package/"
-                "SPDXRef-Package_DYNAMIC_LINK/",
+                "/SPDXRef-DOCUMENT/CONTAINS/SPDXRef-Package/CONTAINS/"
+                "SPDXRef-CommonsLangSrc/GENERATED_FROM/",
+                "/SPDXRef-DOCUMENT/CONTAINS/SPDXRef-Package/DYNAMIC_LINK/",
             ],
         ),
         (
@@ -189,11 +182,9 @@ def test_different_roots_graph() -> None:
                 "SPDXRef-File-C",
             ),
             [
-                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
-                "SPDXRef-Package-A_CONTAINS/",
-                "/SPDXRef-DOCUMENT/SPDXRef-DOCUMENT_DESCRIBES/SPDXRef-Package-A/"
-                "SPDXRef-Package-A_COPY_OF/"
-                "SPDXRef-Package-C/SPDXRef-Package-C_CONTAINS/",
+                "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-A/CONTAINS/",
+                "/SPDXRef-DOCUMENT/DESCRIBES/SPDXRef-Package-A/COPY_OF/"
+                "SPDXRef-Package-C/CONTAINS/",
             ],
         ),
     ],


### PR DESCRIPTION
This PR adds some functionality to add breakpoints in the opossum file. Each folder representing a relationship should be a brekapoint.

This is a subtask of #13. 