### PR TITLE
make script for linting and formatting executable

### DIFF
--- a/scripts/linter_and_formatting.sh
+++ b/scripts/linter_and_formatting.sh
@@ -1,7 +1,8 @@
+#!/usr/bin/env bash
+#
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/..
 


### PR DESCRIPTION
While implementing #20 I didn't notice that adding the license header to the linting script did break the script so that it was no longer executable. By adding the license header below the line to make the script executable the script is still executable and reuse compliant.