### PR TITLE
Issue 13 add information to resources

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -277,14 +277,14 @@ test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "packaging"
-version = "23.0"
+version = "23.1"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
-    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 
 [[package]]
@@ -491,7 +491,7 @@ files = [
 
 [[package]]
 name = "spdx-tools"
-version = "0.7.2.dev381+g91bb7442"
+version = "0.7.2.dev383+gbbccaa12"
 description = "SPDX parser and tools."
 category = "main"
 optional = false
@@ -518,7 +518,7 @@ test = ["pytest"]
 type = "git"
 url = "https://github.com/spdx/tools-python.git"
 reference = "main"
-resolved_reference = "bbccaa12f0f52acb79f17e563d52727f8ac3e331"
+resolved_reference = "eb0c96173fe3afe72e8a70774546cb037bc469fe"
 
 [[package]]
 name = "tomli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [
-    'networkx.*'
+    'networkx.*',
+    'license_expression.*'
 ]
 ignore_missing_imports = true
 

--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict
+
+from spdx.model.document import CreationInfo
+from spdx.model.file import File
+from spdx.model.package import Package
+from spdx.model.snippet import Snippet
+
+from opossum_lib.opossum_file import OpossumPackage, SourceInfo
+
+
+def create_package_attribution(package: Package) -> Dict[str, OpossumPackage]:
+    package_attribution = dict()
+    source = SourceInfo(package.spdx_id, 50)
+    package_attribution[package.spdx_id] = OpossumPackage(
+        source=source,
+        packageName=package.name,
+        url=str(package.download_location),
+        packageVersion=package.version,
+        copyright=str(package.copyright_text),
+        comment=package.comment,
+        licenseName=str(package.license_concluded),
+    )
+
+    return package_attribution
+
+
+def create_file_attribution(file: File) -> Dict[str, OpossumPackage]:
+    file_attributions = dict()
+    source = SourceInfo(file.spdx_id, 50)
+    file_attributions[file.spdx_id] = OpossumPackage(
+        source=source,
+        packageName=file.name.split("/")[-1],
+        copyright=str(file.copyright_text),
+        comment=file.comment,
+        licenseName=str(file.license_concluded),
+    )
+    return file_attributions
+
+
+def create_snippet_attribution(snippet: Snippet) -> Dict[str, OpossumPackage]:
+    snippet_attributions = dict()
+
+    source = SourceInfo(snippet.spdx_id, 50)
+    snippet_attributions[snippet.spdx_id] = OpossumPackage(
+        source=source,
+        packageName=snippet.name,
+        copyright=str(snippet.copyright_text),
+        comment=snippet.comment,
+        licenseName=str(snippet.license_concluded),
+    )
+
+    return snippet_attributions
+
+
+def create_document_attribution(
+    creation_info: CreationInfo,
+) -> Dict[str, OpossumPackage]:
+    document_attributions = dict()
+    source = SourceInfo(creation_info.spdx_id, 50)
+    document_attributions[creation_info.spdx_id] = OpossumPackage(
+        source=source,
+        packageName=creation_info.name,
+        licenseName=creation_info.data_license,
+    )
+
+    return document_attributions

--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict
-
 from spdx.model.document import CreationInfo
 from spdx.model.file import File
 from spdx.model.package import Package
@@ -11,10 +9,9 @@ from spdx.model.snippet import Snippet
 from opossum_lib.opossum_file import OpossumPackage, SourceInfo
 
 
-def create_package_attribution(package: Package) -> Dict[str, OpossumPackage]:
-    package_attribution = dict()
-    source = SourceInfo(package.spdx_id, 50)
-    package_attribution[package.spdx_id] = OpossumPackage(
+def create_package_attribution(package: Package) -> OpossumPackage:
+    source = SourceInfo(package.spdx_id)
+    package_attribution = OpossumPackage(
         source=source,
         packageName=package.name,
         url=str(package.download_location),
@@ -27,24 +24,21 @@ def create_package_attribution(package: Package) -> Dict[str, OpossumPackage]:
     return package_attribution
 
 
-def create_file_attribution(file: File) -> Dict[str, OpossumPackage]:
-    file_attributions = dict()
-    source = SourceInfo(file.spdx_id, 50)
-    file_attributions[file.spdx_id] = OpossumPackage(
+def create_file_attribution(file: File) -> OpossumPackage:
+    source = SourceInfo(file.spdx_id)
+    file_attribution = OpossumPackage(
         source=source,
         packageName=file.name.split("/")[-1],
         copyright=str(file.copyright_text),
         comment=file.comment,
         licenseName=str(file.license_concluded),
     )
-    return file_attributions
+    return file_attribution
 
 
-def create_snippet_attribution(snippet: Snippet) -> Dict[str, OpossumPackage]:
-    snippet_attributions = dict()
-
-    source = SourceInfo(snippet.spdx_id, 50)
-    snippet_attributions[snippet.spdx_id] = OpossumPackage(
+def create_snippet_attribution(snippet: Snippet) -> OpossumPackage:
+    source = SourceInfo(snippet.spdx_id)
+    snippet_attribution = OpossumPackage(
         source=source,
         packageName=snippet.name,
         copyright=str(snippet.copyright_text),
@@ -52,18 +46,17 @@ def create_snippet_attribution(snippet: Snippet) -> Dict[str, OpossumPackage]:
         licenseName=str(snippet.license_concluded),
     )
 
-    return snippet_attributions
+    return snippet_attribution
 
 
 def create_document_attribution(
     creation_info: CreationInfo,
-) -> Dict[str, OpossumPackage]:
-    document_attributions = dict()
-    source = SourceInfo(creation_info.spdx_id, 50)
-    document_attributions[creation_info.spdx_id] = OpossumPackage(
+) -> OpossumPackage:
+    source = SourceInfo(creation_info.spdx_id)
+    document_attribution = OpossumPackage(
         source=source,
         packageName=creation_info.name,
         licenseName=creation_info.data_license,
     )
 
-    return document_attributions
+    return document_attribution

--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -1,89 +1,159 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import datetime
 import json
+from dataclasses import asdict
+from functools import reduce
 from pathlib import Path
-from typing import Any, Dict, List, TypedDict, Union
+from typing import Any, Dict, List, Tuple
 
-from networkx import DiGraph, shortest_path, weakly_connected_components
+from networkx import DiGraph, shortest_path
+from spdx.model.document import CreationInfo
+from spdx.model.file import File
+from spdx.model.package import Package
+from spdx.model.snippet import Snippet
 
-from opossum_lib.helper_methods import (
-    _get_source_for_graph_traversal,
-    _node_represents_a_spdx_element,
+from opossum_lib.attribution_generation import (
+    create_document_attribution,
+    create_file_attribution,
+    create_package_attribution,
+    create_snippet_attribution,
 )
-
-
-class OpossumInformation(TypedDict):
-    metadata: Dict[str, str]
-    resources: Dict[str, Any]
-    externalAttributions: Dict
-    resourcesToAttributions: Dict
-    attributionBreakpoints: List[str]
+from opossum_lib.helper_methods import (
+    _create_file_path_from_graph_path,
+    _create_nested_dict,
+    _get_source_for_graph_traversal,
+    _merge_nested_dicts,
+    _node_represents_a_spdx_element,
+    _replace_node_ids_with_labels,
+    _weakly_connected_component_sub_graphs,
+)
+from opossum_lib.opossum_file import (
+    Metadata,
+    OpossumInformation,
+    OpossumPackage,
+    SourceInfo,
+)
 
 
 def write_dict_to_file(
     opossum_information: OpossumInformation, file_path: Path
 ) -> None:
     with file_path.open("w") as out:
-        json.dump(opossum_information, out, indent=4)
+        json.dump(
+            asdict(opossum_information, dict_factory=dicts_without_none), out, indent=4
+        )
 
 
-def generate_json_file_from_tree(
-    tree: DiGraph,
-) -> OpossumInformation:
-    doc_name = tree.nodes["SPDXRef-DOCUMENT"]["element"].name
+def dicts_without_none(x: List[Tuple[str, Any]]) -> Dict[Any, Any]:
+    return {k: v for (k, v) in x if v is not None}
 
-    opossum_information: OpossumInformation = {
-        "metadata": {
-            "projectId": "tools-python-opossum-crossover",
-            "projectTitle": doc_name,
-            "fileCreationDate": datetime.datetime.utcnow().isoformat(),
-        },
-        "resources": {},
-        "externalAttributions": {},
-        "resourcesToAttributions": {},
-        "attributionBreakpoints": [],
-    }
 
-    for connected_set in weakly_connected_components(tree):
-        connected_subgraph = tree.subgraph(connected_set).copy()
+def generate_json_file_from_tree(tree: DiGraph) -> OpossumInformation:
+    metadata = create_metadata(tree)
+    resources: Dict[str, Any] = dict()
+    resources_to_attributions: Dict[str, List[str]] = dict()
+    external_attributions: Dict[str, OpossumPackage] = dict()
+    attribution_breakpoints = []
+
+    external_attributions["file-identifier"] = OpossumPackage(
+        source=SourceInfo("File", 0)
+    )
+    external_attributions["package-identifier"] = OpossumPackage(
+        source=SourceInfo("Package", 0)
+    )
+    external_attributions["snippet-identifier"] = OpossumPackage(
+        source=SourceInfo("Snippet", 0)
+    )
+
+    for connected_subgraph in _weakly_connected_component_sub_graphs(tree):
         source = _get_source_for_graph_traversal(connected_subgraph)
-        if source is None:  # from development not possible, how to deal with this?
+        if source is None:
             raise RuntimeError(
                 "A tree should always have a node without incoming edge."
             )
+        resources_list = []
+        for node in connected_subgraph.nodes():
+            path: List[str] = shortest_path(connected_subgraph, source, node)
+            path_with_labels: List[str] = _replace_node_ids_with_labels(
+                path, connected_subgraph
+            )
+            file_path: str = _create_file_path_from_graph_path(connected_subgraph, path)
 
-        opossum_information["resources"][source] = tree_to_dict(
-            connected_subgraph, source
-        )
-        opossum_information["attributionBreakpoints"].extend(
-            get_breakpoints(connected_subgraph, source)
-        )
+            resources_list.append(_create_nested_dict(path_with_labels))
+            if _node_represents_a_spdx_element(connected_subgraph, node):
+                create_attribution_and_link_with_resource(
+                    external_attributions,
+                    resources_to_attributions,
+                    file_path,
+                    node,
+                    connected_subgraph,
+                )
 
+            else:
+                attribution_breakpoints.append(file_path)
+
+        resources.update(
+            reduce(
+                lambda dict1, dict2: _merge_nested_dicts(dict1, dict2), resources_list  # type: ignore  # noqa
+            )
+        )
+    opossum_information = OpossumInformation(
+        metadata=metadata,
+        resources=resources,
+        externalAttributions=external_attributions,
+        resourcesToAttributions=resources_to_attributions,
+        attributionBreakpoints=attribution_breakpoints,
+    )
     return opossum_information
 
 
-def tree_to_dict(tree: DiGraph, source: str) -> Union[int, Dict[str, Any]]:
-    successors = list(tree.successors(source))
-    if not successors:
-        return 1
-    branch_dict = {}
-    for successor in successors:
-        successor_name = tree.nodes[successor]["label"]
-        branch_dict[successor_name] = tree_to_dict(tree, successor)
-    return branch_dict
+def create_attribution_and_link_with_resource(
+    external_attributions: Dict[str, OpossumPackage],
+    resources_to_attributions: Dict[str, List[str]],
+    file_path: str,
+    node: str,
+    tree: DiGraph,
+) -> None:
+    if isinstance(tree.nodes[node]["element"], Package):
+        external_attributions.update(
+            create_package_attribution(tree.nodes[node]["element"])
+        )
+        resources_to_attributions[file_path] = [
+            tree.nodes[node]["element"].spdx_id,
+            "package-identifier",
+        ]
+    elif isinstance(tree.nodes[node]["element"], File):
+        external_attributions.update(
+            create_file_attribution(tree.nodes[node]["element"])
+        )
+        resources_to_attributions[file_path] = [
+            tree.nodes[node]["element"].spdx_id,
+            "file-identifier",
+        ]
+    elif isinstance(tree.nodes[node]["element"], Snippet):
+        external_attributions.update(
+            create_snippet_attribution(tree.nodes[node]["element"])
+        )
+        resources_to_attributions[file_path] = [
+            tree.nodes[node]["element"].spdx_id,
+            "snippet-identifier",
+        ]
+    elif isinstance(tree.nodes[node]["element"], CreationInfo):
+        external_attributions.update(
+            create_document_attribution(tree.nodes[node]["element"])
+        )
+        resources_to_attributions[file_path] = [tree.nodes[node]["element"].spdx_id]
+
+    else:
+        external_attributions[node] = OpossumPackage(
+            source=SourceInfo(tree.nodes[node]["label"], 50)
+        )
+        resources_to_attributions[file_path] = [node]
 
 
-def get_breakpoints(tree: DiGraph, source: str) -> List[str]:
-    breakpoints = []
-    for node in tree.nodes():
-        if not _node_represents_a_spdx_element(tree, node):
-            path = shortest_path(tree, source, node)
-            breakpoints.append(_create_file_path_from_graph_path(tree, path))
-
-    return breakpoints
-
-
-def _create_file_path_from_graph_path(graph: DiGraph, path: List[str]) -> str:
-    return "/" + "/".join([graph.nodes[node]["label"] for node in path]) + "/"
+def create_metadata(tree: DiGraph) -> Metadata:
+    doc_name = tree.nodes["SPDXRef-DOCUMENT"]["element"].name
+    created = tree.nodes["SPDXRef-DOCUMENT"]["element"].created
+    metadata = Metadata("tools-python-opossum-crossover", created.isoformat(), doc_name)
+    return metadata

--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -4,7 +4,7 @@
 from typing import Dict, List
 
 from networkx import DiGraph
-from spdx.document_utils import get_contained_spdx_element_ids, get_element_from_spdx_id
+from spdx.document_utils import get_contained_spdx_elements, get_element_from_spdx_id
 from spdx.model.document import Document
 from spdx.model.relationship import Relationship
 
@@ -17,13 +17,16 @@ def generate_graph_from_spdx(document: Document) -> DiGraph:
         label=document.creation_info.spdx_id,
     )
 
-    contained_elements: List[str] = get_contained_spdx_element_ids(document)
+    contained_elements = get_contained_spdx_elements(document)
     contained_element_nodes = [
         (
             spdx_id,
-            {"element": get_element_from_spdx_id(document, spdx_id), "label": spdx_id},
+            {
+                "element": element,
+                "label": element.name or spdx_id,
+            },
         )
-        for spdx_id in contained_elements
+        for spdx_id, element in contained_elements.items()
     ]
     graph.add_nodes_from(contained_element_nodes)
 

--- a/src/opossum_lib/helper_methods.py
+++ b/src/opossum_lib/helper_methods.py
@@ -1,15 +1,17 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
+import typing
+from typing import Any, Dict, List, Optional, Union
 
-from networkx import DiGraph
+from networkx import DiGraph, weakly_connected_components
+from spdx.constants import DOCUMENT_SPDX_ID
 
 
 def _get_source_for_graph_traversal(connected_subgraph: DiGraph) -> Optional[str]:
     return (
-        "SPDXRef-DOCUMENT"
-        if "SPDXRef-DOCUMENT" in connected_subgraph.nodes
+        DOCUMENT_SPDX_ID
+        if DOCUMENT_SPDX_ID in connected_subgraph.nodes
         else _get_node_without_incoming_edge(connected_subgraph)
     )
 
@@ -25,3 +27,71 @@ def _get_node_without_incoming_edge(graph: DiGraph) -> Optional[str]:
 
 def _node_represents_a_spdx_element(graph: DiGraph, node: str) -> bool:
     return "element" in graph.nodes[node]
+
+
+def _weakly_connected_component_sub_graphs(graph: DiGraph) -> List[DiGraph]:
+    connected_sub_graphs = []
+    for connected_set in weakly_connected_components(
+        graph
+    ):  # returns only a set of nodes without edges
+        connected_sub_graphs.append(graph.subgraph(connected_set).copy())
+
+    return connected_sub_graphs
+
+
+def _create_file_path_from_graph_path(graph: DiGraph, path: List[str]) -> str:
+    """
+    some file names with relative paths start with "./", to avoid paths like "/./"
+    we need to remove these prefixes
+    """
+    if list(graph.successors(path[-1])):
+        return (
+            "/"
+            + "/".join([graph.nodes[node]["label"].replace("./", "") for node in path])
+            + "/"
+        )
+    else:
+        return "/" + "/".join(
+            [graph.nodes[node]["label"].replace("./", "") for node in path]
+        )
+
+
+def _replace_node_ids_with_labels(
+    path: List[str], connected_subgraph: DiGraph
+) -> List[str]:
+    resulting_path = []
+    path_with_label = [
+        connected_subgraph.nodes[node]["label"].replace("./", "") for node in path
+    ]
+    for element_or_path in path_with_label:
+        resulting_path.extend(
+            [element for element in element_or_path.split("/") if element]
+        )
+
+    return resulting_path
+
+
+def _create_nested_dict(file_path: List[str]) -> Union[int, Dict[str, Any]]:
+    if len(file_path) == 0:
+        return 1
+    else:
+        return {file_path[0]: _create_nested_dict(file_path[1:])}
+
+
+@typing.no_type_check
+def _merge_nested_dicts(
+    dict1: Union[Dict, int], dict2: Union[Dict, int]
+) -> Dict[str, Any]:
+    if isinstance(dict2, int) and isinstance(dict1, Dict):
+        return dict1
+    if isinstance(dict1, int) and isinstance(dict2, Dict):
+        return dict2
+    if isinstance(dict1, int) and isinstance(dict2, int):
+        raise RuntimeError("A tree doesn't have two equivalent paths.")
+    for key in dict2:
+        if key not in dict1:
+            dict1[key] = dict2[key]
+        else:
+            dict1[key] = _merge_nested_dicts(dict1[key], dict2[key])
+
+    return dict1

--- a/src/opossum_lib/opossum_file.py
+++ b/src/opossum_lib/opossum_file.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Union
+
+
+@dataclass(frozen=True)
+class SourceInfo:
+    name: str
+    documentConfidence: int
+
+
+@dataclass(frozen=True)
+class OpossumPackage:
+    source: SourceInfo
+    attributionConfidence: Optional[int] = None
+    comment: Optional[str] = None
+    packageName: Optional[str] = None
+    packageVersion: Optional[str] = None
+    packageNamespace: Optional[str] = None
+    packageType: Optional[str] = None
+    packagePURLAppendix: Optional[str] = None
+    copyright: Optional[str] = None
+    licenseName: Optional[str] = None
+    licenseText: Optional[str] = None
+    url: Optional[str] = None
+    firstParty: Optional[bool] = None
+    excludeFromNotice: Optional[bool] = None
+    preSelected: Optional[bool] = None
+    followUp: Optional[Literal["FOLLOW_UP"]] = None
+    originId: Optional[str] = None
+    criticality: Optional[Union[Literal["high"], Literal["medium"]]] = None
+
+
+@dataclass(frozen=True)
+class Metadata:
+    projectId: str
+    fileCreationDate: str
+    projectTitle: str
+    projectVersion: Optional[str] = None
+    expectedReleaseDate: Optional[str] = None
+    buildDate: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OpossumInformation:
+    metadata: Metadata
+    resources: Dict[str, Any]
+    externalAttributions: Dict[str, Any]
+    resourcesToAttributions: Dict[str, List[str]]
+    attributionBreakpoints: List[str]

--- a/src/opossum_lib/tree_generation.py
+++ b/src/opossum_lib/tree_generation.py
@@ -1,15 +1,18 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
-from networkx import DiGraph, edge_bfs, is_weakly_connected, weakly_connected_components
+from networkx import DiGraph, edge_bfs, is_weakly_connected
 from spdx.constants import DOCUMENT_SPDX_ID
 from spdx.model.document import CreationInfo
 from spdx.model.file import File
 from spdx.model.package import Package
 
-from opossum_lib.helper_methods import _get_source_for_graph_traversal
+from opossum_lib.helper_methods import (
+    _get_source_for_graph_traversal,
+    _weakly_connected_component_sub_graphs,
+)
 
 
 def generate_tree_from_graph(graph: DiGraph) -> DiGraph:
@@ -96,13 +99,3 @@ def _add_source_node(edge: Tuple[str, str], graph: DiGraph, tree: DiGraph) -> No
             edge[0]
         ]
         tree.add_node(edge[0], **source_node_data)
-
-
-def _weakly_connected_component_sub_graphs(graph: DiGraph) -> List[DiGraph]:
-    connected_sub_graphs = []
-    for connected_set in weakly_connected_components(
-        graph
-    ):  # returns only a set of nodes without edges
-        connected_sub_graphs.append(graph.subgraph(connected_set).copy())
-
-    return connected_sub_graphs

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -34,17 +34,15 @@ def test_create_package_attribution() -> None:
     )
     package_attribution = create_package_attribution(package)
 
-    assert package_attribution == {
-        package.spdx_id: OpossumPackage(
-            source=SourceInfo(package.spdx_id, 50),
-            comment=package.comment,
-            packageName=package.name,
-            packageVersion=package.version,
-            copyright=str(package.copyright_text),
-            url=str(package.download_location),
-            licenseName=str(package.license_concluded),
-        ),
-    }
+    assert package_attribution == OpossumPackage(
+        source=SourceInfo(package.spdx_id),
+        comment=package.comment,
+        packageName=package.name,
+        packageVersion=package.version,
+        copyright=str(package.copyright_text),
+        url=str(package.download_location),
+        licenseName=str(package.license_concluded),
+    )
 
 
 def test_create_file_attribution() -> None:
@@ -58,15 +56,13 @@ def test_create_file_attribution() -> None:
     )
     file_attribution = create_file_attribution(file)
 
-    assert file_attribution == {
-        file.spdx_id: OpossumPackage(
-            source=SourceInfo(file.spdx_id, 50),
-            comment=file.comment,
-            packageName=file.name,
-            copyright=str(file.copyright_text),
-            licenseName=str(file.license_concluded),
-        ),
-    }
+    assert file_attribution == OpossumPackage(
+        source=SourceInfo(file.spdx_id),
+        comment=file.comment,
+        packageName=file.name,
+        copyright=str(file.copyright_text),
+        licenseName=str(file.license_concluded),
+    )
 
 
 def test_create_snippet_attribution() -> None:
@@ -81,15 +77,13 @@ def test_create_snippet_attribution() -> None:
     )
     snippet_attribution = create_snippet_attribution(snippet)
 
-    assert snippet_attribution == {
-        snippet.spdx_id: OpossumPackage(
-            source=SourceInfo(snippet.spdx_id, 50),
-            comment=snippet.comment,
-            packageName=snippet.name,
-            licenseName=str(snippet.license_concluded),
-            copyright=str(snippet.copyright_text),
-        ),
-    }
+    assert snippet_attribution == OpossumPackage(
+        source=SourceInfo(snippet.spdx_id),
+        comment=snippet.comment,
+        packageName=snippet.name,
+        licenseName=str(snippet.license_concluded),
+        copyright=str(snippet.copyright_text),
+    )
 
 
 def test_create_document_attribution() -> None:
@@ -103,10 +97,8 @@ def test_create_document_attribution() -> None:
     )
     document_attribution = create_document_attribution(creation_info)
 
-    assert document_attribution == {
-        creation_info.spdx_id: OpossumPackage(
-            source=SourceInfo(DOCUMENT_SPDX_ID, 50),
-            packageName=creation_info.name,
-            licenseName=creation_info.data_license,
-        ),
-    }
+    assert document_attribution == OpossumPackage(
+        source=SourceInfo(DOCUMENT_SPDX_ID),
+        packageName=creation_info.name,
+        licenseName=creation_info.data_license,
+    )

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+
+from license_expression import get_spdx_licensing
+from spdx.constants import DOCUMENT_SPDX_ID
+from spdx.model.actor import Actor, ActorType
+from spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx.model.document import CreationInfo
+from spdx.model.file import File as SpdxFile
+from spdx.model.package import Package as SpdxPackage
+from spdx.model.snippet import Snippet as SpdxSnippet
+from spdx.model.spdx_no_assertion import SpdxNoAssertion
+
+from opossum_lib.attribution_generation import (
+    create_document_attribution,
+    create_file_attribution,
+    create_package_attribution,
+    create_snippet_attribution,
+)
+from opossum_lib.opossum_file import OpossumPackage, SourceInfo
+
+
+def test_create_package_attribution() -> None:
+    package = SpdxPackage(
+        name="Test Package",
+        spdx_id="SPDXRef-Package",
+        download_location="https://download.com",
+        version="2.1.0",
+        license_concluded=get_spdx_licensing().parse("MIT AND LGPL-2.0"),
+        comment="Package comment",
+        copyright_text=SpdxNoAssertion(),
+    )
+    package_attribution = create_package_attribution(package)
+
+    assert package_attribution == {
+        package.spdx_id: OpossumPackage(
+            source=SourceInfo(package.spdx_id, 50),
+            comment=package.comment,
+            packageName=package.name,
+            packageVersion=package.version,
+            copyright=str(package.copyright_text),
+            url=str(package.download_location),
+            licenseName=str(package.license_concluded),
+        ),
+    }
+
+
+def test_create_file_attribution() -> None:
+    file = SpdxFile(
+        name="Test File",
+        spdx_id="SPDXRef-File",
+        checksums=[Checksum(ChecksumAlgorithm.SHA1, "")],
+        license_concluded=get_spdx_licensing().parse("Apache-2.0 OR MIT"),
+        comment="File comment",
+        copyright_text="Copyright (c) 2023 someone",
+    )
+    file_attribution = create_file_attribution(file)
+
+    assert file_attribution == {
+        file.spdx_id: OpossumPackage(
+            source=SourceInfo(file.spdx_id, 50),
+            comment=file.comment,
+            packageName=file.name,
+            copyright=str(file.copyright_text),
+            licenseName=str(file.license_concluded),
+        ),
+    }
+
+
+def test_create_snippet_attribution() -> None:
+    snippet = SpdxSnippet(
+        name="Test Snippet",
+        spdx_id="SPDXRef-Snippet",
+        file_spdx_id="SPDXRef-File",
+        byte_range=(1, 2),
+        license_concluded=get_spdx_licensing().parse("MIT AND LGPL-2.0"),
+        comment="Snippet comment",
+        copyright_text=SpdxNoAssertion(),
+    )
+    snippet_attribution = create_snippet_attribution(snippet)
+
+    assert snippet_attribution == {
+        snippet.spdx_id: OpossumPackage(
+            source=SourceInfo(snippet.spdx_id, 50),
+            comment=snippet.comment,
+            packageName=snippet.name,
+            licenseName=str(snippet.license_concluded),
+            copyright=str(snippet.copyright_text),
+        ),
+    }
+
+
+def test_create_document_attribution() -> None:
+    creation_info = CreationInfo(
+        name="Test Document",
+        spdx_id=DOCUMENT_SPDX_ID,
+        spdx_version="SPDX2.3",
+        document_namespace="some.namespace",
+        creators=[Actor(ActorType.PERSON, "Name")],
+        created=datetime.utcnow(),
+    )
+    document_attribution = create_document_attribution(creation_info)
+
+    assert document_attribution == {
+        creation_info.spdx_id: OpossumPackage(
+            source=SourceInfo(DOCUMENT_SPDX_ID, 50),
+            packageName=creation_info.name,
+            licenseName=creation_info.data_license,
+        ),
+    }

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -35,7 +35,7 @@ def test_different_paths_graph() -> None:
 
     opossum_information = generate_json_file_from_tree(tree)
 
-    file_tree = opossum_information.resources
+    file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
     TestCase().assertCountEqual(
         opossum_information.attributionBreakpoints,
@@ -66,7 +66,7 @@ def test_different_paths_graph() -> None:
     }
 
     TestCase().assertCountEqual(
-        opossum_information.externalAttributions,
+        opossum_information.externalAttributions.keys(),
         [
             "SPDXRef-DOCUMENT",
             "SPDXRef-Package-A",
@@ -104,7 +104,7 @@ def test_unconnected_paths_graph() -> None:
 
     opossum_information = generate_json_file_from_tree(tree)
 
-    file_tree = opossum_information.resources
+    file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
     TestCase().assertCountEqual(
         opossum_information.attributionBreakpoints,
@@ -140,7 +140,7 @@ def test_unconnected_paths_graph() -> None:
     }
 
     TestCase().assertCountEqual(
-        opossum_information.externalAttributions,
+        opossum_information.externalAttributions.keys(),
         [
             "SPDXRef-DOCUMENT",
             "SPDXRef-Package-A",
@@ -170,7 +170,7 @@ def test_different_roots_graph() -> None:
     tree = generate_tree_from_graph(graph)
     opossum_information = generate_json_file_from_tree(tree)
 
-    file_tree = opossum_information.resources
+    file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
     TestCase().assertCountEqual(
         opossum_information.attributionBreakpoints,
@@ -200,7 +200,7 @@ def test_different_roots_graph() -> None:
     }
 
     TestCase().assertCountEqual(
-        opossum_information.externalAttributions,
+        opossum_information.externalAttributions.keys(),
         [
             "SPDXRef-DOCUMENT",
             "SPDXRef-Package-A",
@@ -269,7 +269,8 @@ def test_tree_generation_for_bigger_examples(
     tree = generate_tree_from_graph(graph)
     opossum_information = generate_json_file_from_tree(tree)
 
-    file_tree = opossum_information.resources
+    file_tree = opossum_information.resources.to_dict()
+    assert isinstance(file_tree, dict)
     assert len(file_tree.keys()) == expected_top_level_keys
     assert (
         file_tree[expected_file_path_level_1[0]][expected_file_path_level_1[1]][

--- a/tests/test_helper_methods.py
+++ b/tests/test_helper_methods.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from functools import reduce
+
+from opossum_lib.helper_methods import _merge_nested_dicts
+
+
+def test_merge_nested_dicts() -> None:
+    list_of_dicts = [{"A": 1}, {"A": {"B": {"C": 1}}}, {"A": {"B": 1}}, {"A": {"D": 1}}]
+
+    merged_dict = reduce(
+        lambda dict1, dict2: _merge_nested_dicts(dict1, dict2), list_of_dicts  # type: ignore # noqa
+    )
+
+    assert merged_dict == {"A": {"B": {"C": 1}, "D": 1}}

--- a/tests/test_helper_methods.py
+++ b/tests/test_helper_methods.py
@@ -1,16 +1,41 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from functools import reduce
+from unittest import TestCase
 
-from opossum_lib.helper_methods import _merge_nested_dicts
+from networkx import DiGraph
+
+from opossum_lib.helper_methods import (
+    _create_file_path_from_graph_path,
+    _replace_node_ids_with_labels,
+)
 
 
-def test_merge_nested_dicts() -> None:
-    list_of_dicts = [{"A": 1}, {"A": {"B": {"C": 1}}}, {"A": {"B": 1}}, {"A": {"D": 1}}]
+def test_create_file_path_from_graph_path() -> None:
+    graph = _create_simple_graph()
+    path = ["root", "node", "leaf"]
 
-    merged_dict = reduce(
-        lambda dict1, dict2: _merge_nested_dicts(dict1, dict2), list_of_dicts  # type: ignore # noqa
+    file_path = _create_file_path_from_graph_path(path, graph)
+
+    assert file_path == "/root/node/with/path/leaf"
+
+
+def test_replace_node_ids_with_labels() -> None:
+    graph = _create_simple_graph()
+    path = ["root", "node", "leaf"]
+
+    file_path = _replace_node_ids_with_labels(path, graph)
+
+    TestCase().assertCountEqual(file_path, ["root", "node", "with", "path", "leaf"])
+
+
+def _create_simple_graph() -> DiGraph:
+    graph = DiGraph()
+    graph.add_nodes_from(
+        [
+            ("root", {"label": "root"}),
+            ("node", {"label": "node/with/path"}),
+            ("leaf", {"label": "leaf"}),
+        ]
     )
-
-    assert merged_dict == {"A": {"B": {"C": 1}, "D": 1}}
+    return graph

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from opossum_lib.opossum_file import Resource
+
+
+def test_resource_to_dict() -> None:
+    list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    resource = Resource()
+
+    for path in list_of_paths:
+        resource.add_path(path)
+
+    assert resource.to_dict() == {"A": {"B": {"C": 1}, "D": 1}}


### PR DESCRIPTION
This PR adds more information to the generated opossum file. We create attributions for each spdx element and link them with the corresponding file path in the resources dict. 

I decided to iterate thorugh all nodes and create the attributions, resources and the linking node by node. This implies the need of a method to merge several nested dicts (`_merge_nested_dict`). I am having some problems with the type hints and mypy here so I decided to disbale type checking here, maybe we can have a look at this together. 
