### PR TITLE
[issue_26] add validation to cli and more tests

### DIFF
--- a/src/opossum_lib/cli.py
+++ b/src/opossum_lib/cli.py
@@ -13,6 +13,7 @@ import click
 from spdx.model.document import Document as SpdxDocument
 from spdx.parser.error import SPDXParsingError
 from spdx.parser.parse_anything import parse_file
+from spdx.validation.document_validator import validate_full_spdx_document
 
 from opossum_lib.file_generation import generate_json_file_from_tree, write_dict_to_file
 from opossum_lib.graph_generation import generate_graph_from_spdx
@@ -48,6 +49,12 @@ def spdx2opossum(infile: str, outfile: str) -> None:
         )
         logging.error(log_string)
         sys.exit(1)
+    validation_messages = validate_full_spdx_document(document)
+    if validation_messages:
+        logging.warning(
+            "The given SPDX document is not valid, this might cause "
+            "issues with the conversion."
+        )
 
     graph = generate_graph_from_spdx(document)
     tree = generate_tree_from_graph(graph)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,13 +6,16 @@ from pathlib import Path
 from typing import Tuple
 
 import pytest
+from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
+from spdx.writer.tagvalue.tagvalue_writer import write_document_to_file
 
 from opossum_lib.cli import spdx2opossum
+from tests.helper_methods import _create_minimal_document
 
 
 @pytest.mark.parametrize("options", [("--infile", "--outfile"), ("-i", "-o")])
-def test_cli(tmp_path: Path, options: Tuple[str, str]) -> None:
+def test_cli_with_system_exit_code_0(tmp_path: Path, options: Tuple[str, str]) -> None:
     runner = CliRunner()
 
     result = runner.invoke(
@@ -30,3 +33,33 @@ def test_cli(tmp_path: Path, options: Tuple[str, str]) -> None:
     with open(tmp_path / "output.json") as file:
         opossum_dict = json.load(file)
     assert "metadata" in opossum_dict
+
+
+def test_cli_with_system_exit_code_1() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("invalid_spdx.spdx", "w") as f:
+            f.write("SPDXID: SPDXRef-DOCUMENT")
+        result = runner.invoke(spdx2opossum, "-i invalid_spdx.spdx -o invalid")
+
+    assert result.exit_code == 1
+
+
+def test_cli_with_invalid_document(caplog: LogCaptureFixture) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        create_invalid_spdx_document("invalid_spdx.spdx")
+        result = runner.invoke(spdx2opossum, "-i invalid_spdx.spdx -o invalid")
+
+    assert result.output == ""
+    assert caplog.messages == [
+        "The given SPDX document is not valid, this might cause issues with "
+        "the conversion."
+    ]
+
+
+def create_invalid_spdx_document(file_path: str) -> None:
+    document = _create_minimal_document()
+    document.creation_info.spdx_id = "DocumentID"
+
+    write_document_to_file(document, file_path, False)


### PR DESCRIPTION
We talked  about the necessity of valid SPDX documents in some review comment but I forgot to add it in #18.

I decided to just raise a warning as not all validation problems would cause an issue with the implementation. If you think it would be bettter to raise an error and exit, let me know and I can change this.

fixes #26