### PR TITLE
[issue_25] use graph generation from tools-python

### DIFF
--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -1,81 +1,16 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, List
-
 from networkx import DiGraph
-from spdx_tools.spdx.document_utils import (
-    get_contained_spdx_elements,
-    get_element_from_spdx_id,
-)
+from spdx_tools.spdx.graph_generation import generate_relationship_graph_from_spdx
 from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import Relationship
 
 
 def generate_graph_from_spdx(document: Document) -> DiGraph:
-    graph = DiGraph()
-    graph.add_node(
-        document.creation_info.spdx_id,
-        element=document.creation_info,
-        label=document.creation_info.spdx_id,
-    )
-
-    contained_elements = get_contained_spdx_elements(document)
-    contained_element_nodes = [
-        (
-            spdx_id,
-            {
-                "element": element,
-                "label": element.name or spdx_id,
-            },
-        )
-        for spdx_id, element in contained_elements.items()
-    ]
-    graph.add_nodes_from(contained_element_nodes)
-
-    relationships_by_spdx_id: Dict[
-        str, List[Relationship]
-    ] = _get_relationships_by_spdx_id(document.relationships)
-
-    for spdx_id, relationships in relationships_by_spdx_id.items():
-        if spdx_id not in graph.nodes():
-            graph.add_node(
-                spdx_id,
-                element=get_element_from_spdx_id(document, spdx_id),
-                label=spdx_id,
-            )
-        for relationship in relationships:
-            relationship_node_key = (
-                relationship.spdx_element_id + "_" + relationship.relationship_type.name
-            )
-            graph.add_node(
-                relationship_node_key,
-                comment=relationship.comment,
-                label=relationship.relationship_type.name,
-            )
-            graph.add_edge(relationship.spdx_element_id, relationship_node_key)
-            # if the related spdx element is SpdxNone or SpdxNoAssertion we need a
-            # type conversion
-            related_spdx_element_id = str(relationship.related_spdx_element_id)
-
-            if related_spdx_element_id not in graph.nodes():
-                graph.add_node(
-                    related_spdx_element_id,
-                    element=get_element_from_spdx_id(document, related_spdx_element_id),
-                    label=related_spdx_element_id,
-                )
-            graph.add_edge(relationship_node_key, related_spdx_element_id)
-
+    graph = generate_relationship_graph_from_spdx(document)
+    for node in graph.nodes():
+        if "_" in node:
+            graph.add_node(node, label=node.split("_", 1)[-1])
+        else:
+            graph.add_node(node, label=node)
     return graph
-
-
-def _get_relationships_by_spdx_id(
-    relationships: List[Relationship],
-) -> Dict[str, List[Relationship]]:
-    relationships_by_spdx_id: Dict[str, List[Relationship]] = dict()
-    for relationship in relationships:
-        relationships_by_spdx_id.setdefault(relationship.spdx_element_id, []).append(
-            relationship
-        )
-
-    return relationships_by_spdx_id

--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -1,16 +1,32 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from networkx import DiGraph
+from typing import Optional, Union
+
+from networkx import DiGraph, set_node_attributes
 from spdx_tools.spdx.graph_generation import generate_relationship_graph_from_spdx
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import File, Package, Snippet
+from spdx_tools.spdx.model.document import CreationInfo, Document
+
+from opossum_lib.helper_methods import _node_represents_a_spdx_element
 
 
 def generate_graph_from_spdx(document: Document) -> DiGraph:
     graph = generate_relationship_graph_from_spdx(document)
-    for node in graph.nodes():
-        if "_" in node:
-            graph.add_node(node, label=node.split("_", 1)[-1])
-        else:
-            graph.add_node(node, label=node)
+    labels = {node: _create_label_for_node(graph, node) for node in graph.nodes}
+    set_node_attributes(graph, labels, "label")
+
     return graph
+
+
+def _create_label_for_node(graph: DiGraph, node: str) -> str:
+    if _node_represents_a_spdx_element(graph, node):
+        element_node: Optional[
+            Union[CreationInfo, File, Package, Snippet]
+        ] = graph.nodes[node]["element"]
+        if element_node:
+            return element_node.name or element_node.spdx_id
+        else:
+            return node
+    else:
+        return node.split("_", 1)[-1]

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -21,7 +21,7 @@ from tests.helper_methods import (
 def test_different_paths_graph() -> None:
     """Creating a tree from a directed graph with a cycle."""
     expected_file_tree = {
-        "SPDXRef-DOCUMENT": {
+        "SPDX Lite Document": {
             "DESCRIBES": {
                 "Example package A": {"CONTAINS": {"Example file": 1}},
                 "Example package B": {"CONTAINS": {"Example file": 1}},
@@ -40,26 +40,26 @@ def test_different_paths_graph() -> None:
     TestCase().assertCountEqual(
         opossum_information.attributionBreakpoints,
         [
-            "/SPDXRef-DOCUMENT/DESCRIBES/",
-            "/SPDXRef-DOCUMENT/DESCRIBES/Example package A/CONTAINS/",
-            "/SPDXRef-DOCUMENT/DESCRIBES/Example package B/CONTAINS/",
+            "/SPDX Lite Document/DESCRIBES/",
+            "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/",
+            "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/",
         ],
     )
     assert opossum_information.resourcesToAttributions == {
-        "/SPDXRef-DOCUMENT/": ["SPDXRef-DOCUMENT"],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package A/": [
+        "/SPDX Lite Document/": ["SPDXRef-DOCUMENT"],
+        "/SPDX Lite Document/DESCRIBES/Example package A/": [
             "SPDXRef-Package-A",
             "package-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package A/CONTAINS/Example file": [
+        "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/Example file": [
             "SPDXRef-File",
             "file-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package B/": [
+        "/SPDX Lite Document/DESCRIBES/Example package B/": [
             "SPDXRef-Package-B",
             "package-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package B/CONTAINS/Example file": [
+        "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/Example file": [
             "SPDXRef-File",
             "file-identifier",
         ],
@@ -82,7 +82,7 @@ def test_different_paths_graph() -> None:
 def test_unconnected_paths_graph() -> None:
     """Creating a tree from a directed graph with a cycle."""
     expected_file_tree = {
-        "SPDXRef-DOCUMENT": {
+        "SPDX Lite Document": {
             "DESCRIBES": {
                 "Example package A": {"CONTAINS": {"Example file": 1}},
                 "Example package B": {"CONTAINS": {"Example file": 1}},
@@ -109,27 +109,27 @@ def test_unconnected_paths_graph() -> None:
     TestCase().assertCountEqual(
         opossum_information.attributionBreakpoints,
         [
-            "/SPDXRef-DOCUMENT/DESCRIBES/",
-            "/SPDXRef-DOCUMENT/DESCRIBES/Example package A/CONTAINS/",
-            "/SPDXRef-DOCUMENT/DESCRIBES/Example package B/CONTAINS/",
+            "/SPDX Lite Document/DESCRIBES/",
+            "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/",
+            "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/",
         ],
     )
 
     assert opossum_information.resourcesToAttributions == {
-        "/SPDXRef-DOCUMENT/": ["SPDXRef-DOCUMENT"],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package A/": [
+        "/SPDX Lite Document/": ["SPDXRef-DOCUMENT"],
+        "/SPDX Lite Document/DESCRIBES/Example package A/": [
             "SPDXRef-Package-A",
             "package-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package A/CONTAINS/Example file": [
+        "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/Example file": [
             "SPDXRef-File",
             "file-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package B/": [
+        "/SPDX Lite Document/DESCRIBES/Example package B/": [
             "SPDXRef-Package-B",
             "package-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Example package B/CONTAINS/Example file": [
+        "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/Example file": [
             "SPDXRef-File",
             "file-identifier",
         ],
@@ -156,11 +156,11 @@ def test_unconnected_paths_graph() -> None:
 
 def test_different_roots_graph() -> None:
     """Creating a tree from a connected graph where some edges are not reachable
-    from the SPDXRef-DOCUMENT node. This means that the connected graph has multiple
+    from the SPDX Lite Document node. This means that the connected graph has multiple
     sources and thus the result should be disconnected."""
     expected_file_tree = {
         "File-B": {"DESCRIBES": {"Package-B": 1}},
-        "SPDXRef-DOCUMENT": {
+        "Document": {
             "DESCRIBES": {"Package-A": {"CONTAINS": {"File-A": 1}}, "Package-B": 1}
         },
     }
@@ -175,8 +175,8 @@ def test_different_roots_graph() -> None:
     TestCase().assertCountEqual(
         opossum_information.attributionBreakpoints,
         [
-            "/SPDXRef-DOCUMENT/DESCRIBES/",
-            "/SPDXRef-DOCUMENT/DESCRIBES/Package-A/CONTAINS/",
+            "/Document/DESCRIBES/",
+            "/Document/DESCRIBES/Package-A/CONTAINS/",
             "/File-B/DESCRIBES/",
         ],
     )
@@ -184,16 +184,16 @@ def test_different_roots_graph() -> None:
     assert opossum_information.resourcesToAttributions == {
         "/File-B/": ["SPDXRef-File-B", "file-identifier"],
         "/File-B/DESCRIBES/Package-B": ["SPDXRef-Package-B", "package-identifier"],
-        "/SPDXRef-DOCUMENT/": ["SPDXRef-DOCUMENT"],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Package-A/": [
+        "/Document/": ["SPDXRef-DOCUMENT"],
+        "/Document/DESCRIBES/Package-A/": [
             "SPDXRef-Package-A",
             "package-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Package-A/CONTAINS/File-A": [
+        "/Document/DESCRIBES/Package-A/CONTAINS/File-A": [
             "SPDXRef-File-A",
             "file-identifier",
         ],
-        "/SPDXRef-DOCUMENT/DESCRIBES/Package-B": [
+        "/Document/DESCRIBES/Package-B": [
             "SPDXRef-Package-B",
             "package-identifier",
         ],
@@ -222,37 +222,38 @@ def test_different_roots_graph() -> None:
             "SPDXJSONExample-v2.3.spdx.json",
             3,
             (
-                "SPDXRef-DOCUMENT",
+                "SPDX-Tools-v2.0",
                 "COPY_OF",
                 "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
             ),
             (
-                "SPDXRef-DOCUMENT",
+                "SPDX-Tools-v2.0",
                 "CONTAINS",
                 "glibc",
                 "DYNAMIC_LINK",
                 "Saxon",
             ),
             [
-                "/SPDXRef-DOCUMENT/CONTAINS/glibc/CONTAINS/"
+                "/SPDX-Tools-v2.0/CONTAINS/glibc/CONTAINS/"
                 "lib-source/commons-lang3-3.1-sources.jar/GENERATED_FROM/",
-                "/SPDXRef-DOCUMENT/CONTAINS/glibc/DYNAMIC_LINK/",
+                "/SPDX-Tools-v2.0/CONTAINS/glibc/DYNAMIC_LINK/",
             ],
         ),
         (
             "SPDX.spdx",
             2,
-            ("SPDXRef-DOCUMENT", "DESCRIBES", "Package B"),
+            ("SPDX Lite Document", "DESCRIBES", "Package B"),
             (
-                "SPDXRef-DOCUMENT",
+                "SPDX Lite Document",
                 "DESCRIBES",
                 "Package A",
                 "CONTAINS",
                 "File-C",
             ),
             [
-                "/SPDXRef-DOCUMENT/DESCRIBES/Package A/CONTAINS/",
-                "/SPDXRef-DOCUMENT/DESCRIBES/Package A/COPY_OF/" "Package C/CONTAINS/",
+                "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
+                "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/"
+                "Package C/CONTAINS/",
             ],
         ),
     ],

--- a/tests/test_graph_generation.py
+++ b/tests/test_graph_generation.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 from typing import List
-from unittest import TestCase
 
 import pytest
+from networkx import get_node_attributes
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
@@ -44,6 +44,8 @@ def test_generate_graph_from_spdx(
     for relationship_node_key in relationship_node_keys:
         assert relationship_node_key in graph.nodes()
 
+    assert "DESCRIBES" in get_node_attributes(graph, "label").values()
+
     assert validation_messages == []
 
 
@@ -52,30 +54,16 @@ def test_complete_connected_graph() -> None:
 
     graph = generate_graph_from_spdx(document)
 
-    TestCase().assertCountEqual(
-        graph.nodes(),
-        [
-            "SPDXRef-DOCUMENT",
-            "SPDXRef-Package-A",
-            "SPDXRef-Package-B",
-            "SPDXRef-File",
-            "SPDXRef-DOCUMENT_DESCRIBES",
-            "SPDXRef-Package-A_CONTAINS",
-            "SPDXRef-Package-B_CONTAINS",
-        ],
-    )
-    TestCase().assertCountEqual(
-        graph.edges(),
-        [
-            ("SPDXRef-DOCUMENT", "SPDXRef-DOCUMENT_DESCRIBES"),
-            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-A"),
-            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-B"),
-            ("SPDXRef-Package-A", "SPDXRef-Package-A_CONTAINS"),
-            ("SPDXRef-Package-A_CONTAINS", "SPDXRef-File"),
-            ("SPDXRef-Package-B", "SPDXRef-Package-B_CONTAINS"),
-            ("SPDXRef-Package-B_CONTAINS", "SPDXRef-File"),
-        ],
-    )
+    labels = get_node_attributes(graph, "label")
+    assert labels == {
+        "SPDXRef-DOCUMENT": "SPDXRef-DOCUMENT",
+        "SPDXRef-Package-A": "SPDXRef-Package-A",
+        "SPDXRef-Package-B": "SPDXRef-Package-B",
+        "SPDXRef-File": "SPDXRef-File",
+        "SPDXRef-DOCUMENT_DESCRIBES": "DESCRIBES",
+        "SPDXRef-Package-A_CONTAINS": "CONTAINS",
+        "SPDXRef-Package-B_CONTAINS": "CONTAINS",
+    }
 
 
 def test_complete_unconnected_graph() -> None:
@@ -90,28 +78,14 @@ def test_complete_unconnected_graph() -> None:
 
     graph = generate_graph_from_spdx(document)
 
-    TestCase().assertCountEqual(
-        graph.nodes(),
-        [
-            "SPDXRef-DOCUMENT",
-            "SPDXRef-Package-A",
-            "SPDXRef-Package-B",
-            "SPDXRef-File",
-            "SPDXRef-DOCUMENT_DESCRIBES",
-            "SPDXRef-Package-A_CONTAINS",
-            "SPDXRef-Package-B_CONTAINS",
-            "SPDXRef-Package-C",
-        ],
-    )
-    TestCase().assertCountEqual(
-        graph.edges(),
-        [
-            ("SPDXRef-DOCUMENT", "SPDXRef-DOCUMENT_DESCRIBES"),
-            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-A"),
-            ("SPDXRef-DOCUMENT_DESCRIBES", "SPDXRef-Package-B"),
-            ("SPDXRef-Package-A", "SPDXRef-Package-A_CONTAINS"),
-            ("SPDXRef-Package-A_CONTAINS", "SPDXRef-File"),
-            ("SPDXRef-Package-B", "SPDXRef-Package-B_CONTAINS"),
-            ("SPDXRef-Package-B_CONTAINS", "SPDXRef-File"),
-        ],
-    )
+    labels = get_node_attributes(graph, "label")
+    assert labels == {
+        "SPDXRef-DOCUMENT": "SPDXRef-DOCUMENT",
+        "SPDXRef-Package-A": "SPDXRef-Package-A",
+        "SPDXRef-Package-B": "SPDXRef-Package-B",
+        "SPDXRef-File": "SPDXRef-File",
+        "SPDXRef-DOCUMENT_DESCRIBES": "DESCRIBES",
+        "SPDXRef-Package-A_CONTAINS": "CONTAINS",
+        "SPDXRef-Package-B_CONTAINS": "CONTAINS",
+        "SPDXRef-Package-C": "SPDXRef-Package-C",
+    }

--- a/tests/test_graph_generation.py
+++ b/tests/test_graph_generation.py
@@ -56,12 +56,12 @@ def test_complete_connected_graph() -> None:
 
     labels = get_node_attributes(graph, "label")
     assert labels == {
-        "SPDXRef-DOCUMENT": "SPDXRef-DOCUMENT",
-        "SPDXRef-Package-A": "SPDXRef-Package-A",
-        "SPDXRef-Package-B": "SPDXRef-Package-B",
-        "SPDXRef-File": "SPDXRef-File",
+        "SPDXRef-DOCUMENT": "SPDX Lite Document",
         "SPDXRef-DOCUMENT_DESCRIBES": "DESCRIBES",
+        "SPDXRef-File": "Example file",
+        "SPDXRef-Package-A": "Example package A",
         "SPDXRef-Package-A_CONTAINS": "CONTAINS",
+        "SPDXRef-Package-B": "Example package B",
         "SPDXRef-Package-B_CONTAINS": "CONTAINS",
     }
 
@@ -80,12 +80,12 @@ def test_complete_unconnected_graph() -> None:
 
     labels = get_node_attributes(graph, "label")
     assert labels == {
-        "SPDXRef-DOCUMENT": "SPDXRef-DOCUMENT",
-        "SPDXRef-Package-A": "SPDXRef-Package-A",
-        "SPDXRef-Package-B": "SPDXRef-Package-B",
-        "SPDXRef-File": "SPDXRef-File",
+        "SPDXRef-DOCUMENT": "SPDX Lite Document",
         "SPDXRef-DOCUMENT_DESCRIBES": "DESCRIBES",
+        "SPDXRef-File": "Example file",
+        "SPDXRef-Package-A": "Example package A",
         "SPDXRef-Package-A_CONTAINS": "CONTAINS",
+        "SPDXRef-Package-B": "Example package B",
         "SPDXRef-Package-B_CONTAINS": "CONTAINS",
-        "SPDXRef-Package-C": "SPDXRef-Package-C",
+        "SPDXRef-Package-C": "Package without connection to document",
     }


### PR DESCRIPTION
The current implementation in `tools-python` doesn't add labels to the graph, so I decided to keep the previous method and use it as some kind of wrapper and add the labels accordingly. I also updated the tests to check if the labels are set correctly. 

fixes #25