### PR TITLE
update imports due to changes in upstream package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -384,14 +384,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.3.0"
+version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
-    {file = "pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 
 [package.dependencies]
@@ -518,7 +518,7 @@ test = ["pytest"]
 type = "git"
 url = "https://github.com/spdx/tools-python.git"
 reference = "main"
-resolved_reference = "eb0c96173fe3afe72e8a70774546cb037bc469fe"
+resolved_reference = "8d7d7b7d38ba5c50ddaa3d0023c620566dfc4e49"
 
 [[package]]
 name = "tomli"

--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from spdx.model.document import CreationInfo
-from spdx.model.file import File
-from spdx.model.package import Package
-from spdx.model.snippet import Snippet
+from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.model.snippet import Snippet
 
 from opossum_lib.opossum_file import OpossumPackage, SourceInfo
 

--- a/src/opossum_lib/cli.py
+++ b/src/opossum_lib/cli.py
@@ -10,10 +10,10 @@ import sys
 from pathlib import Path
 
 import click
-from spdx.model.document import Document as SpdxDocument
-from spdx.parser.error import SPDXParsingError
-from spdx.parser.parse_anything import parse_file
-from spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.model.document import Document as SpdxDocument
+from spdx_tools.spdx.parser.error import SPDXParsingError
+from spdx_tools.spdx.parser.parse_anything import parse_file
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 
 from opossum_lib.file_generation import generate_json_file_from_tree, write_dict_to_file
 from opossum_lib.graph_generation import generate_graph_from_spdx

--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from networkx import DiGraph, shortest_path
-from spdx.model.document import CreationInfo
-from spdx.model.file import File
-from spdx.model.package import Package
-from spdx.model.snippet import Snippet
+from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.model.snippet import Snippet
 
 from opossum_lib.attribution_generation import (
     create_document_attribution,

--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -4,9 +4,12 @@
 from typing import Dict, List
 
 from networkx import DiGraph
-from spdx.document_utils import get_contained_spdx_elements, get_element_from_spdx_id
-from spdx.model.document import Document
-from spdx.model.relationship import Relationship
+from spdx_tools.spdx.document_utils import (
+    get_contained_spdx_elements,
+    get_element_from_spdx_id,
+)
+from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model.relationship import Relationship
 
 
 def generate_graph_from_spdx(document: Document) -> DiGraph:

--- a/src/opossum_lib/helper_methods.py
+++ b/src/opossum_lib/helper_methods.py
@@ -4,7 +4,7 @@
 from typing import List, Optional
 
 from networkx import DiGraph, weakly_connected_components
-from spdx.constants import DOCUMENT_SPDX_ID
+from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
 
 
 def _get_source_for_graph_traversal(connected_subgraph: DiGraph) -> Optional[str]:

--- a/src/opossum_lib/tree_generation.py
+++ b/src/opossum_lib/tree_generation.py
@@ -4,10 +4,10 @@
 from typing import Dict, Optional, Tuple, Union
 
 from networkx import DiGraph, edge_bfs, is_weakly_connected
-from spdx.constants import DOCUMENT_SPDX_ID
-from spdx.model.document import CreationInfo
-from spdx.model.file import File
-from spdx.model.package import Package
+from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
+from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model.package import Package
 
 from opossum_lib.helper_methods import (
     _get_source_for_graph_traversal,

--- a/tests/helper_methods.py
+++ b/tests/helper_methods.py
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
-from spdx.model.actor import Actor, ActorType
-from spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx.model.document import CreationInfo, Document
-from spdx.model.file import File
-from spdx.model.package import Package
-from spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model.document import CreationInfo, Document
+from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
 
 
 def _create_minimal_document() -> Document:

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -4,14 +4,14 @@
 from datetime import datetime
 
 from license_expression import get_spdx_licensing
-from spdx.constants import DOCUMENT_SPDX_ID
-from spdx.model.actor import Actor, ActorType
-from spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx.model.document import CreationInfo
-from spdx.model.file import File as SpdxFile
-from spdx.model.package import Package as SpdxPackage
-from spdx.model.snippet import Snippet as SpdxSnippet
-from spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
+from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model.file import File as SpdxFile
+from spdx_tools.spdx.model.package import Package as SpdxPackage
+from spdx_tools.spdx.model.snippet import Snippet as SpdxSnippet
+from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 
 from opossum_lib.attribution_generation import (
     create_document_attribution,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from typing import Tuple
 import pytest
 from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
-from spdx.writer.tagvalue.tagvalue_writer import write_document_to_file
+from spdx_tools.spdx.writer.tagvalue.tagvalue_writer import write_document_to_file
 
 from opossum_lib.cli import spdx2opossum
 from tests.helper_methods import _create_minimal_document

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -6,8 +6,8 @@ from typing import List, Tuple
 from unittest import TestCase
 
 import pytest
-from spdx.model.package import Package
-from spdx.parser.parse_anything import parse_file
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.parser.parse_anything import parse_file
 
 from opossum_lib.file_generation import generate_json_file_from_tree
 from opossum_lib.graph_generation import generate_graph_from_spdx

--- a/tests/test_graph_generation.py
+++ b/tests/test_graph_generation.py
@@ -6,9 +6,9 @@ from typing import List
 from unittest import TestCase
 
 import pytest
-from spdx.model.package import Package
-from spdx.parser.parse_anything import parse_file
-from spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.parser.parse_anything import parse_file
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 
 from opossum_lib.graph_generation import generate_graph_from_spdx
 from tests.helper_methods import _create_minimal_document

--- a/tests/test_tree_generation.py
+++ b/tests/test_tree_generation.py
@@ -7,13 +7,13 @@ from unittest import TestCase
 
 import pytest
 from networkx import is_weakly_connected
-from spdx.model.actor import Actor, ActorType
-from spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx.model.document import CreationInfo, Document
-from spdx.model.file import File
-from spdx.model.package import Package
-from spdx.model.relationship import Relationship, RelationshipType
-from spdx.parser.parse_anything import parse_file
+from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model.document import CreationInfo, Document
+from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.parser.parse_anything import parse_file
 
 from opossum_lib.graph_generation import generate_graph_from_spdx
 from opossum_lib.tree_generation import generate_tree_from_graph


### PR DESCRIPTION
The structure of `tools-python` has changed, so we need to update all import paths and the lock file. 