### PR TITLE
[issue_32] fix conversion to dict

### DIFF
--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import copy
 import json
 from dataclasses import fields
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List, Union
 
 from networkx import DiGraph, shortest_path
 from spdx_tools.spdx.model.document import CreationInfo
@@ -43,7 +42,22 @@ def write_dict_to_file(
         json.dump(to_dict(opossum_information), out, indent=4)
 
 
-def to_dict(element: Any) -> Any:
+def to_dict(
+    element: Union[
+        Resource,
+        Metadata,
+        OpossumPackage,
+        OpossumInformation,
+        SourceInfo,
+        str,
+        int,
+        bool,
+        Dict[str, OpossumPackage],
+        Dict[str, List[str]],
+        List[str],
+        None,
+    ]
+) -> Union[Dict, str, List[str], bool, int, None]:
     if isinstance(element, Resource):
         return element.to_dict()
     if isinstance(element, (Metadata, OpossumPackage, OpossumInformation, SourceInfo)):
@@ -53,9 +67,9 @@ def to_dict(element: Any) -> Any:
             result.append((f.name, value))
         return {k: v for (k, v) in result if v is not None}
     elif isinstance(element, dict):
-        return type(element)((to_dict(k), to_dict(v)) for k, v in element.items())
+        return {k: to_dict(v) for k, v in element.items()}
     else:
-        return copy.deepcopy(element)
+        return element
 
 
 def generate_json_file_from_tree(tree: DiGraph) -> OpossumInformation:

--- a/tests/data/expected_opossum.json
+++ b/tests/data/expected_opossum.json
@@ -1,0 +1,160 @@
+{
+  "metadata": {
+    "projectId": "tools-python-opossum-crossover",
+    "fileCreationDate": "2023-03-14T08:49:00",
+    "projectTitle": "SPDX Lite Document"
+  },
+  "resources": {
+    "SPDX Lite Document": {
+      "DESCRIBES": {
+        "Package A": {
+          "CONTAINS": {
+            "File-A": 1,
+            "File-C": 1
+          },
+          "COPY_OF": {
+            "Package C": {
+              "CONTAINS": {
+                "File-B": 1
+              }
+            }
+          }
+        },
+        "Package B": 1
+      }
+    },
+    "SPDXRef-Snippet": 1
+  },
+  "externalAttributions": {
+    "file-identifier": {
+      "source": {
+        "name": "File",
+        "documentConfidence": 0
+      }
+    },
+    "package-identifier": {
+      "source": {
+        "name": "Package",
+        "documentConfidence": 0
+      }
+    },
+    "snippet-identifier": {
+      "source": {
+        "name": "Snippet",
+        "documentConfidence": 0
+      }
+    },
+    "SPDXRef-DOCUMENT": {
+      "source": {
+        "name": "SPDXRef-DOCUMENT",
+        "documentConfidence": 0
+      },
+      "packageName": "SPDX Lite Document",
+      "licenseName": "CC0-1.0"
+    },
+    "SPDXRef-Package-A": {
+      "source": {
+        "name": "SPDXRef-Package-A",
+        "documentConfidence": 0
+      },
+      "packageName": "Package A",
+      "copyright": "None",
+      "licenseName": "None",
+      "url": "https://download.com"
+    },
+    "SPDXRef-Package-B": {
+      "source": {
+        "name": "SPDXRef-Package-B",
+        "documentConfidence": 0
+      },
+      "packageName": "Package B",
+      "copyright": "None",
+      "licenseName": "None",
+      "url": "https://download.com"
+    },
+    "SPDXRef-File-A": {
+      "source": {
+        "name": "SPDXRef-File-A",
+        "documentConfidence": 0
+      },
+      "packageName": "File-A",
+      "copyright": "None",
+      "licenseName": "None"
+    },
+    "SPDXRef-File-C": {
+      "source": {
+        "name": "SPDXRef-File-C",
+        "documentConfidence": 0
+      },
+      "packageName": "File-C",
+      "copyright": "None",
+      "licenseName": "None"
+    },
+    "SPDXRef-Package-C": {
+      "source": {
+        "name": "SPDXRef-Package-C",
+        "documentConfidence": 0
+      },
+      "packageName": "Package C",
+      "copyright": "None",
+      "licenseName": "None",
+      "url": "https://download.com"
+    },
+    "SPDXRef-File-B": {
+      "source": {
+        "name": "SPDXRef-File-B",
+        "documentConfidence": 0
+      },
+      "packageName": "File-B",
+      "copyright": "None",
+      "licenseName": "None"
+    },
+    "SPDXRef-Snippet": {
+      "source": {
+        "name": "SPDXRef-Snippet",
+        "documentConfidence": 0
+      },
+      "copyright": "None",
+      "licenseName": "None"
+    }
+  },
+  "resourcesToAttributions": {
+    "/SPDX Lite Document/": [
+      "SPDXRef-DOCUMENT"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package A/": [
+      "SPDXRef-Package-A",
+      "package-identifier"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package B": [
+      "SPDXRef-Package-B",
+      "package-identifier"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/File-A": [
+      "SPDXRef-File-A",
+      "file-identifier"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/File-C": [
+      "SPDXRef-File-C",
+      "file-identifier"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/": [
+      "SPDXRef-Package-C",
+      "package-identifier"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/CONTAINS/File-B": [
+      "SPDXRef-File-B",
+      "file-identifier"
+    ],
+    "/SPDXRef-Snippet": [
+      "SPDXRef-Snippet",
+      "snippet-identifier"
+    ]
+  },
+  "attributionBreakpoints": [
+    "/SPDX Lite Document/DESCRIBES/",
+    "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/",
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/CONTAINS/"
+  ]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,12 +27,17 @@ def test_cli_with_system_exit_code_0(tmp_path: Path, options: Tuple[str, str]) -
             str(tmp_path / "output"),
         ],
     )
+    with open(
+        Path(__file__).resolve().parent / "data" / "expected_opossum.json"
+    ) as file:
+        expected_opossum_dict = json.load(file)
 
     assert result.exit_code == 0
 
     with open(tmp_path / "output.json") as file:
         opossum_dict = json.load(file)
     assert "metadata" in opossum_dict
+    assert opossum_dict == expected_opossum_dict
 
 
 def test_cli_with_system_exit_code_1() -> None:


### PR DESCRIPTION
This PR fixes the conversion from `OpossumPackage` to dict. As I used the `asdict` method before, the `to_dict()` method of the `Resource` objects wasn't called and the generated output included additional `children` tags. I didn't notice this as we didn't have a test to check the actual output. So, I added a test to check the generated opossum file and fixed the issue. I decided to write a custom `to_dict` method as the `asdict` method from `dataclasses` doesn't allow different `dict_factories` for nested dataclasses. The type hints for this method are rather general to avoid complains from `mypy`. 

#fixes 32