### PR TITLE
add flake support

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+name: "Test flake integration"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix build
+    - run: nix flake check

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1682526928,
+        "narHash": "sha256-2cKh4O6t1rQ8Ok+v16URynmb0rV7oZPEbXkU0owNLQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6b863fd9b7bb962e6f9fdf292419a775e772891",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1682646291,
+        "narHash": "sha256-1t6Jtc/NXDVWDuR2O4mXB9LlmKc7OB4rG6vEaqewlMo=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "34702e36ce973dcfac4e25666c59fce72210099b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "An early WIP library for handling Opossum files with Python";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.poetry2nix = {
+    url = "github:nix-community/poetry2nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # see https://github.com/nix-community/poetry2nix/tree/master#api for more functions and examples.
+        inherit (poetry2nix.legacyPackages.${system}) mkPoetryApplication;
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          opossum-lib-py = mkPoetryApplication { projectDir = self; };
+          default = self.packages.${system}.opossum-lib-py;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [ poetry2nix.packages.${system}.poetry ];
+        };
+      });
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ description = "A library for handling Opossum files with Python"
 authors = [
     "Meret Behrens <meret.behrens@tngtech.com>",
     "Jakob Schubert <jakob.schubert@tngtech.com>",
+    "Maximilian Huber <maximilian.huber@tngtech.com>",
 ]
 license = "Apache-2.0"
 
@@ -37,6 +38,10 @@ black = "^23.1.0"
 isort = "^5.12.0"
 flake8 = "^6.0.0"
 mypy = "^1.1.1"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [virtualenvs]
 in-project = true


### PR DESCRIPTION
This is currently failing to build the license-expression dependency:

```
error: builder for '/nix/store/hadzd22512dpsbq4l56rc32r0y2lsidr-python3.10-license-expression-30.1.0.drv' failed with exit code 1;
       last 10 log lines:
       > source root is license-expression-30.1.0
       > setting SOURCE_DATE_EPOCH to timestamp 1673980441 of file license-expression-30.1.0/setup.cfg
       > patching sources
       > Removing path dependencies
       > Finished removing path dependencies
       > Removing git dependencies
       > Finished removing git dependencies
       > configuring
       > configure flags: --prefix=/nix/store/62d35g1kn8fms5w3gm4qsf57lrffnx5v-python3.10-license-expression-30.1.0
       > /nix/store/kk3qbkyrski18j8fwrpd5dgvplbdz7b2-stdenv-linux/setup: line 1289: ./configure: cannot execute: required file not found
       For full logs, run 'nix log /nix/store/hadzd22512dpsbq4l56rc32r0y2lsidr-python3.10-license-expression-30.1.0.drv'.
error: 1 dependencies of derivation '/nix/store/5dmv6fwxam2rzg6cy2k1ffl8r7hr9n82-python3.10-spdx-tools-0.8.0a1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/z4jw2ckrkfs66l3ch4xhr7n09qjg9kv9-python3.10-opossum-lib-py-0.1.drv' failed to build
```