### PR TITLE
[issue-41] add purl to OpossumPackage if present in SPDXPackage

### DIFF
--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -1,12 +1,21 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
 from spdx_tools.spdx.model.document import CreationInfo
 from spdx_tools.spdx.model.file import File
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.model.snippet import Snippet
 
 from opossum_lib.opossum_file import OpossumPackage, SourceInfo
+
+
+def _get_purl(package: Package) -> Optional[str]:
+    for external_reference in package.external_references:
+        if external_reference.reference_type == "purl":
+            return external_reference.locator
+    return None
 
 
 def create_package_attribution(package: Package) -> OpossumPackage:
@@ -16,6 +25,7 @@ def create_package_attribution(package: Package) -> OpossumPackage:
         packageName=package.name,
         url=str(package.download_location),
         packageVersion=package.version,
+        packagePURLAppendix=_get_purl(package),
         copyright=str(package.copyright_text),
         comment=package.comment,
         licenseName=str(package.license_concluded),

--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -8,12 +8,13 @@ from spdx_tools.spdx.model.file import File
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.model.snippet import Snippet
 
+from opossum_lib.constants import PURL
 from opossum_lib.opossum_file import OpossumPackage, SourceInfo
 
 
 def _get_purl(package: Package) -> Optional[str]:
     for external_reference in package.external_references:
-        if external_reference.reference_type == "purl":
+        if external_reference.reference_type == PURL:
             return external_reference.locator
     return None
 

--- a/src/opossum_lib/constants.py
+++ b/src/opossum_lib/constants.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+PURL = "purl"

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -9,6 +9,7 @@ from spdx_tools.spdx.model.actor import Actor, ActorType
 from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.model.document import CreationInfo
 from spdx_tools.spdx.model.file import File as SpdxFile
+from spdx_tools.spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory
 from spdx_tools.spdx.model.package import Package as SpdxPackage
 from spdx_tools.spdx.model.snippet import Snippet as SpdxSnippet
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
@@ -31,6 +32,13 @@ def test_create_package_attribution() -> None:
         license_concluded=get_spdx_licensing().parse("MIT AND LGPL-2.0"),
         comment="Package comment",
         copyright_text=SpdxNoAssertion(),
+        external_references=[
+            ExternalPackageRef(
+                ExternalPackageRefCategory.PACKAGE_MANAGER,
+                "purl",
+                "pkg:maven/org.apache.jena/apache-jena@3.12.0",
+            )
+        ],
     )
     package_attribution = create_package_attribution(package)
 
@@ -42,6 +50,7 @@ def test_create_package_attribution() -> None:
         copyright=str(package.copyright_text),
         url=str(package.download_location),
         licenseName=str(package.license_concluded),
+        packagePURLAppendix="pkg:maven/org.apache.jena/apache-jena@3.12.0",
     )
 
 


### PR DESCRIPTION
If an SPDX package contains an external reference including a purl we add the locator of the purl to the `packagePURLAppendix` field in the corresponding OpossumPackage. 

part of #41