### PR TITLE
Refactor: Use externalAttributionSources instead of signals to label SPDX elements

### DIFF
--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -20,7 +20,7 @@ def _get_purl(package: Package) -> Optional[str]:
 
 
 def create_package_attribution(package: Package) -> OpossumPackage:
-    source = SourceInfo(package.spdx_id)
+    source = SourceInfo("SPDX-Package")
     package_attribution = OpossumPackage(
         source=source,
         packageName=package.name,
@@ -36,7 +36,7 @@ def create_package_attribution(package: Package) -> OpossumPackage:
 
 
 def create_file_attribution(file: File) -> OpossumPackage:
-    source = SourceInfo(file.spdx_id)
+    source = SourceInfo("SPDX-File")
     file_attribution = OpossumPackage(
         source=source,
         packageName=file.name.split("/")[-1],
@@ -48,7 +48,7 @@ def create_file_attribution(file: File) -> OpossumPackage:
 
 
 def create_snippet_attribution(snippet: Snippet) -> OpossumPackage:
-    source = SourceInfo(snippet.spdx_id)
+    source = SourceInfo("SPDX-Snippet")
     snippet_attribution = OpossumPackage(
         source=source,
         packageName=snippet.name,

--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -8,7 +8,12 @@ from spdx_tools.spdx.model.file import File
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.model.snippet import Snippet
 
-from opossum_lib.constants import PURL
+from opossum_lib.constants import (
+    PURL,
+    SPDX_FILE_IDENTIFIER,
+    SPDX_PACKAGE_IDENTIFIER,
+    SPDX_SNIPPET_IDENTIFIER,
+)
 from opossum_lib.opossum_file import OpossumPackage, SourceInfo
 
 
@@ -20,7 +25,7 @@ def _get_purl(package: Package) -> Optional[str]:
 
 
 def create_package_attribution(package: Package) -> OpossumPackage:
-    source = SourceInfo("SPDX-Package")
+    source = SourceInfo(SPDX_PACKAGE_IDENTIFIER)
     package_attribution = OpossumPackage(
         source=source,
         packageName=package.name,
@@ -36,7 +41,7 @@ def create_package_attribution(package: Package) -> OpossumPackage:
 
 
 def create_file_attribution(file: File) -> OpossumPackage:
-    source = SourceInfo("SPDX-File")
+    source = SourceInfo(SPDX_FILE_IDENTIFIER)
     file_attribution = OpossumPackage(
         source=source,
         packageName=file.name.split("/")[-1],
@@ -48,7 +53,7 @@ def create_file_attribution(file: File) -> OpossumPackage:
 
 
 def create_snippet_attribution(snippet: Snippet) -> OpossumPackage:
-    source = SourceInfo("SPDX-Snippet")
+    source = SourceInfo(SPDX_SNIPPET_IDENTIFIER)
     snippet_attribution = OpossumPackage(
         source=source,
         packageName=snippet.name,

--- a/src/opossum_lib/constants.py
+++ b/src/opossum_lib/constants.py
@@ -2,3 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 PURL = "purl"
+SPDX_FILE_IDENTIFIER = "SPDX-File"
+SPDX_PACKAGE_IDENTIFIER = "SPDX-Package"
+SPDX_SNIPPET_IDENTIFIER = "SPDX-Snippet"

--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -18,6 +18,11 @@ from opossum_lib.attribution_generation import (
     create_package_attribution,
     create_snippet_attribution,
 )
+from opossum_lib.constants import (
+    SPDX_FILE_IDENTIFIER,
+    SPDX_PACKAGE_IDENTIFIER,
+    SPDX_SNIPPET_IDENTIFIER,
+)
 from opossum_lib.helper_methods import (
     _create_file_path_from_graph_path,
     _get_source_for_graph_traversal,
@@ -90,9 +95,13 @@ def generate_json_file_from_tree(tree: DiGraph) -> OpossumInformation:
     external_attributions: Dict[str, OpossumPackage] = dict()
     attribution_breakpoints = []
     external_attribution_sources = {
-        "SPDX-File": ExternalAttributionSource("SPDX-File", 500),
-        "SPDX-Package": ExternalAttributionSource("SPDX-Package", 500),
-        "SPDX-Snippet": ExternalAttributionSource("SPDX-Snippet", 500),
+        SPDX_FILE_IDENTIFIER: ExternalAttributionSource(SPDX_FILE_IDENTIFIER, 500),
+        SPDX_PACKAGE_IDENTIFIER: ExternalAttributionSource(
+            SPDX_PACKAGE_IDENTIFIER, 500
+        ),
+        SPDX_SNIPPET_IDENTIFIER: ExternalAttributionSource(
+            SPDX_SNIPPET_IDENTIFIER, 500
+        ),
     }
 
     for connected_subgraph in _weakly_connected_component_sub_graphs(tree):

--- a/src/opossum_lib/opossum_file.py
+++ b/src/opossum_lib/opossum_file.py
@@ -18,6 +18,9 @@ class OpossumInformation:
         OpossumPackageIdentifier, List[OpossumPackageIdentifier]
     ]
     attributionBreakpoints: List[str]
+    externalAttributionSources: Dict[str, ExternalAttributionSource] = field(
+        default_factory=dict
+    )
 
 
 @dataclass(frozen=True)
@@ -77,3 +80,9 @@ class Resource:
             return {
                 name: resource.to_dict() for name, resource in self.children.items()
             }
+
+
+@dataclass(frozen=True)
+class ExternalAttributionSource:
+    name: str
+    priority: int

--- a/tests/data/expected_opossum.json
+++ b/tests/data/expected_opossum.json
@@ -1,7 +1,102 @@
 {
+  "attributionBreakpoints": [
+    "/SPDX Lite Document/DESCRIBES/",
+    "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/",
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/CONTAINS/"
+  ],
+  "externalAttributionSources": {
+    "SPDX-File": {
+      "name": "SPDX-File",
+      "priority": 500
+    },
+    "SPDX-Package": {
+      "name": "SPDX-Package",
+      "priority": 500
+    },
+    "SPDX-Snippet": {
+      "name": "SPDX-Snippet",
+      "priority": 500
+    }
+  },
+  "externalAttributions": {
+    "SPDXRef-DOCUMENT": {
+      "licenseName": "CC0-1.0",
+      "packageName": "SPDX Lite Document",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDXRef-DOCUMENT"
+      }
+    },
+    "SPDXRef-File-A": {
+      "copyright": "None",
+      "licenseName": "None",
+      "packageName": "File-A",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-File"
+      }
+    },
+    "SPDXRef-File-B": {
+      "copyright": "None",
+      "licenseName": "None",
+      "packageName": "File-B",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-File"
+      }
+    },
+    "SPDXRef-File-C": {
+      "copyright": "None",
+      "licenseName": "None",
+      "packageName": "File-C",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-File"
+      }
+    },
+    "SPDXRef-Package-A": {
+      "copyright": "None",
+      "licenseName": "None",
+      "packageName": "Package A",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-Package"
+      },
+      "url": "https://download.com"
+    },
+    "SPDXRef-Package-B": {
+      "copyright": "None",
+      "licenseName": "None",
+      "packageName": "Package B",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-Package"
+      },
+      "url": "https://download.com"
+    },
+    "SPDXRef-Package-C": {
+      "copyright": "None",
+      "licenseName": "None",
+      "packageName": "Package C",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-Package"
+      },
+      "url": "https://download.com"
+    },
+    "SPDXRef-Snippet": {
+      "copyright": "None",
+      "licenseName": "None",
+      "source": {
+        "documentConfidence": 0,
+        "name": "SPDX-Snippet"
+      }
+    }
+  },
   "metadata": {
-    "projectId": "tools-python-opossum-crossover",
     "fileCreationDate": "2023-03-14T08:49:00",
+    "projectId": "tools-python-opossum-crossover",
     "projectTitle": "SPDX Lite Document"
   },
   "resources": {
@@ -25,136 +120,30 @@
     },
     "SPDXRef-Snippet": 1
   },
-  "externalAttributions": {
-    "file-identifier": {
-      "source": {
-        "name": "File",
-        "documentConfidence": 0
-      }
-    },
-    "package-identifier": {
-      "source": {
-        "name": "Package",
-        "documentConfidence": 0
-      }
-    },
-    "snippet-identifier": {
-      "source": {
-        "name": "Snippet",
-        "documentConfidence": 0
-      }
-    },
-    "SPDXRef-DOCUMENT": {
-      "source": {
-        "name": "SPDXRef-DOCUMENT",
-        "documentConfidence": 0
-      },
-      "packageName": "SPDX Lite Document",
-      "licenseName": "CC0-1.0"
-    },
-    "SPDXRef-Package-A": {
-      "source": {
-        "name": "SPDXRef-Package-A",
-        "documentConfidence": 0
-      },
-      "packageName": "Package A",
-      "copyright": "None",
-      "licenseName": "None",
-      "url": "https://download.com"
-    },
-    "SPDXRef-Package-B": {
-      "source": {
-        "name": "SPDXRef-Package-B",
-        "documentConfidence": 0
-      },
-      "packageName": "Package B",
-      "copyright": "None",
-      "licenseName": "None",
-      "url": "https://download.com"
-    },
-    "SPDXRef-File-A": {
-      "source": {
-        "name": "SPDXRef-File-A",
-        "documentConfidence": 0
-      },
-      "packageName": "File-A",
-      "copyright": "None",
-      "licenseName": "None"
-    },
-    "SPDXRef-File-C": {
-      "source": {
-        "name": "SPDXRef-File-C",
-        "documentConfidence": 0
-      },
-      "packageName": "File-C",
-      "copyright": "None",
-      "licenseName": "None"
-    },
-    "SPDXRef-Package-C": {
-      "source": {
-        "name": "SPDXRef-Package-C",
-        "documentConfidence": 0
-      },
-      "packageName": "Package C",
-      "copyright": "None",
-      "licenseName": "None",
-      "url": "https://download.com"
-    },
-    "SPDXRef-File-B": {
-      "source": {
-        "name": "SPDXRef-File-B",
-        "documentConfidence": 0
-      },
-      "packageName": "File-B",
-      "copyright": "None",
-      "licenseName": "None"
-    },
-    "SPDXRef-Snippet": {
-      "source": {
-        "name": "SPDXRef-Snippet",
-        "documentConfidence": 0
-      },
-      "copyright": "None",
-      "licenseName": "None"
-    }
-  },
   "resourcesToAttributions": {
     "/SPDX Lite Document/": [
       "SPDXRef-DOCUMENT"
     ],
     "/SPDX Lite Document/DESCRIBES/Package A/": [
-      "SPDXRef-Package-A",
-      "package-identifier"
-    ],
-    "/SPDX Lite Document/DESCRIBES/Package B": [
-      "SPDXRef-Package-B",
-      "package-identifier"
+      "SPDXRef-Package-A"
     ],
     "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/File-A": [
-      "SPDXRef-File-A",
-      "file-identifier"
+      "SPDXRef-File-A"
     ],
     "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/File-C": [
-      "SPDXRef-File-C",
-      "file-identifier"
+      "SPDXRef-File-C"
     ],
     "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/": [
-      "SPDXRef-Package-C",
-      "package-identifier"
+      "SPDXRef-Package-C"
     ],
     "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/CONTAINS/File-B": [
-      "SPDXRef-File-B",
-      "file-identifier"
+      "SPDXRef-File-B"
+    ],
+    "/SPDX Lite Document/DESCRIBES/Package B": [
+      "SPDXRef-Package-B"
     ],
     "/SPDXRef-Snippet": [
-      "SPDXRef-Snippet",
-      "snippet-identifier"
+      "SPDXRef-Snippet"
     ]
-  },
-  "attributionBreakpoints": [
-    "/SPDX Lite Document/DESCRIBES/",
-    "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
-    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/",
-    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/CONTAINS/"
-  ]
+  }
 }

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -20,6 +20,11 @@ from opossum_lib.attribution_generation import (
     create_package_attribution,
     create_snippet_attribution,
 )
+from opossum_lib.constants import (
+    SPDX_FILE_IDENTIFIER,
+    SPDX_PACKAGE_IDENTIFIER,
+    SPDX_SNIPPET_IDENTIFIER,
+)
 from opossum_lib.opossum_file import OpossumPackage, SourceInfo
 
 
@@ -43,7 +48,7 @@ def test_create_package_attribution() -> None:
     package_attribution = create_package_attribution(package)
 
     assert package_attribution == OpossumPackage(
-        source=SourceInfo("SPDX-Package"),
+        source=SourceInfo(SPDX_PACKAGE_IDENTIFIER),
         comment=package.comment,
         packageName=package.name,
         packageVersion=package.version,
@@ -66,7 +71,7 @@ def test_create_file_attribution() -> None:
     file_attribution = create_file_attribution(file)
 
     assert file_attribution == OpossumPackage(
-        source=SourceInfo("SPDX-File"),
+        source=SourceInfo(SPDX_FILE_IDENTIFIER),
         comment=file.comment,
         packageName=file.name,
         copyright=str(file.copyright_text),
@@ -87,7 +92,7 @@ def test_create_snippet_attribution() -> None:
     snippet_attribution = create_snippet_attribution(snippet)
 
     assert snippet_attribution == OpossumPackage(
-        source=SourceInfo("SPDX-Snippet"),
+        source=SourceInfo(SPDX_SNIPPET_IDENTIFIER),
         comment=snippet.comment,
         packageName=snippet.name,
         licenseName=str(snippet.license_concluded),

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -43,7 +43,7 @@ def test_create_package_attribution() -> None:
     package_attribution = create_package_attribution(package)
 
     assert package_attribution == OpossumPackage(
-        source=SourceInfo(package.spdx_id),
+        source=SourceInfo("SPDX-Package"),
         comment=package.comment,
         packageName=package.name,
         packageVersion=package.version,
@@ -66,7 +66,7 @@ def test_create_file_attribution() -> None:
     file_attribution = create_file_attribution(file)
 
     assert file_attribution == OpossumPackage(
-        source=SourceInfo(file.spdx_id),
+        source=SourceInfo("SPDX-File"),
         comment=file.comment,
         packageName=file.name,
         copyright=str(file.copyright_text),
@@ -87,7 +87,7 @@ def test_create_snippet_attribution() -> None:
     snippet_attribution = create_snippet_attribution(snippet)
 
     assert snippet_attribution == OpossumPackage(
-        source=SourceInfo(snippet.spdx_id),
+        source=SourceInfo("SPDX-Snippet"),
         comment=snippet.comment,
         packageName=snippet.name,
         licenseName=str(snippet.license_concluded),

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -11,6 +11,7 @@ from spdx_tools.spdx.parser.parse_anything import parse_file
 
 from opossum_lib.file_generation import generate_json_file_from_tree
 from opossum_lib.graph_generation import generate_graph_from_spdx
+from opossum_lib.opossum_file import ExternalAttributionSource
 from opossum_lib.tree_generation import generate_tree_from_graph
 from tests.helper_methods import (
     _create_minimal_document,
@@ -47,21 +48,13 @@ def test_different_paths_graph() -> None:
     )
     assert opossum_information.resourcesToAttributions == {
         "/SPDX Lite Document/": ["SPDXRef-DOCUMENT"],
-        "/SPDX Lite Document/DESCRIBES/Example package A/": [
-            "SPDXRef-Package-A",
-            "package-identifier",
-        ],
+        "/SPDX Lite Document/DESCRIBES/Example package A/": ["SPDXRef-Package-A"],
         "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/Example file": [
-            "SPDXRef-File",
-            "file-identifier",
+            "SPDXRef-File"
         ],
-        "/SPDX Lite Document/DESCRIBES/Example package B/": [
-            "SPDXRef-Package-B",
-            "package-identifier",
-        ],
+        "/SPDX Lite Document/DESCRIBES/Example package B/": ["SPDXRef-Package-B"],
         "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/Example file": [
-            "SPDXRef-File",
-            "file-identifier",
+            "SPDXRef-File"
         ],
     }
 
@@ -70,13 +63,16 @@ def test_different_paths_graph() -> None:
         [
             "SPDXRef-DOCUMENT",
             "SPDXRef-Package-A",
-            "package-identifier",
             "SPDXRef-File",
-            "file-identifier",
             "SPDXRef-Package-B",
-            "snippet-identifier",
         ],
     )
+
+    assert opossum_information.externalAttributionSources == {
+        "SPDX-File": ExternalAttributionSource("SPDX-File", 500),
+        "SPDX-Package": ExternalAttributionSource("SPDX-Package", 500),
+        "SPDX-Snippet": ExternalAttributionSource("SPDX-Snippet", 500),
+    }
 
 
 def test_unconnected_paths_graph() -> None:
@@ -117,26 +113,15 @@ def test_unconnected_paths_graph() -> None:
 
     assert opossum_information.resourcesToAttributions == {
         "/SPDX Lite Document/": ["SPDXRef-DOCUMENT"],
-        "/SPDX Lite Document/DESCRIBES/Example package A/": [
-            "SPDXRef-Package-A",
-            "package-identifier",
-        ],
+        "/SPDX Lite Document/DESCRIBES/Example package A/": ["SPDXRef-Package-A"],
         "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/Example file": [
-            "SPDXRef-File",
-            "file-identifier",
+            "SPDXRef-File"
         ],
-        "/SPDX Lite Document/DESCRIBES/Example package B/": [
-            "SPDXRef-Package-B",
-            "package-identifier",
-        ],
+        "/SPDX Lite Document/DESCRIBES/Example package B/": ["SPDXRef-Package-B"],
         "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/Example file": [
-            "SPDXRef-File",
-            "file-identifier",
+            "SPDXRef-File"
         ],
-        "/Package without connection to document": [
-            "SPDXRef-Package-C",
-            "package-identifier",
-        ],
+        "/Package without connection to document": ["SPDXRef-Package-C"],
     }
 
     TestCase().assertCountEqual(
@@ -144,11 +129,8 @@ def test_unconnected_paths_graph() -> None:
         [
             "SPDXRef-DOCUMENT",
             "SPDXRef-Package-A",
-            "package-identifier",
             "SPDXRef-File",
-            "file-identifier",
             "SPDXRef-Package-B",
-            "snippet-identifier",
             "SPDXRef-Package-C",
         ],
     )
@@ -182,21 +164,12 @@ def test_different_roots_graph() -> None:
     )
 
     assert opossum_information.resourcesToAttributions == {
-        "/File-B/": ["SPDXRef-File-B", "file-identifier"],
-        "/File-B/DESCRIBES/Package-B": ["SPDXRef-Package-B", "package-identifier"],
+        "/File-B/": ["SPDXRef-File-B"],
+        "/File-B/DESCRIBES/Package-B": ["SPDXRef-Package-B"],
         "/Document/": ["SPDXRef-DOCUMENT"],
-        "/Document/DESCRIBES/Package-A/": [
-            "SPDXRef-Package-A",
-            "package-identifier",
-        ],
-        "/Document/DESCRIBES/Package-A/CONTAINS/File-A": [
-            "SPDXRef-File-A",
-            "file-identifier",
-        ],
-        "/Document/DESCRIBES/Package-B": [
-            "SPDXRef-Package-B",
-            "package-identifier",
-        ],
+        "/Document/DESCRIBES/Package-A/": ["SPDXRef-Package-A"],
+        "/Document/DESCRIBES/Package-A/CONTAINS/File-A": ["SPDXRef-File-A"],
+        "/Document/DESCRIBES/Package-B": ["SPDXRef-Package-B"],
     }
 
     TestCase().assertCountEqual(
@@ -204,12 +177,9 @@ def test_different_roots_graph() -> None:
         [
             "SPDXRef-DOCUMENT",
             "SPDXRef-Package-A",
-            "package-identifier",
             "SPDXRef-File-A",
             "SPDXRef-File-B",
-            "file-identifier",
             "SPDXRef-Package-B",
-            "snippet-identifier",
         ],
     )
 

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -9,6 +9,11 @@ import pytest
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.parser.parse_anything import parse_file
 
+from opossum_lib.constants import (
+    SPDX_FILE_IDENTIFIER,
+    SPDX_PACKAGE_IDENTIFIER,
+    SPDX_SNIPPET_IDENTIFIER,
+)
 from opossum_lib.file_generation import generate_json_file_from_tree
 from opossum_lib.graph_generation import generate_graph_from_spdx
 from opossum_lib.opossum_file import ExternalAttributionSource
@@ -69,9 +74,13 @@ def test_different_paths_graph() -> None:
     )
 
     assert opossum_information.externalAttributionSources == {
-        "SPDX-File": ExternalAttributionSource("SPDX-File", 500),
-        "SPDX-Package": ExternalAttributionSource("SPDX-Package", 500),
-        "SPDX-Snippet": ExternalAttributionSource("SPDX-Snippet", 500),
+        SPDX_FILE_IDENTIFIER: ExternalAttributionSource(SPDX_FILE_IDENTIFIER, 500),
+        SPDX_PACKAGE_IDENTIFIER: ExternalAttributionSource(
+            SPDX_PACKAGE_IDENTIFIER, 500
+        ),
+        SPDX_SNIPPET_IDENTIFIER: ExternalAttributionSource(
+            SPDX_SNIPPET_IDENTIFIER, 500
+        ),
     }
 
 


### PR DESCRIPTION
Similar to the opossum file generated by the Haskell tooling, this PR adds `externalAttributionSources` to label the SPDX elements (file, package or snippet). Previously we added an additional signal for this (as shown in the screenshot below). 
![image](https://github.com/opossum-tool/opossum.lib.py/assets/50019307/ba5fe042-1c95-4119-95d2-49cb38eea53a)

With these changes the SPDXID of each element is no longer visible but instead all packages / files / snippets included in an SPDX element are grouped under "SPDX-Package" / "SPDX-File" / "SPDX_Snippet" in the list of signals (see the screenshot below).  
![image](https://github.com/opossum-tool/opossum.lib.py/assets/50019307/3f398d6b-1543-400e-bf80-9c2dd11d9d64)
