### PR TITLE
[issue-46] Merge opossum datastructures

### DIFF
--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import json
+import uuid
 from dataclasses import fields
 from pathlib import Path
 from typing import Dict, List, Union
@@ -189,5 +190,5 @@ def create_attribution_and_link_with_resource(
 def create_metadata(tree: DiGraph) -> Metadata:
     doc_name = tree.nodes["SPDXRef-DOCUMENT"]["element"].name
     created = tree.nodes["SPDXRef-DOCUMENT"]["element"].created
-    metadata = Metadata("tools-python-opossum-crossover", created.isoformat(), doc_name)
+    metadata = Metadata(str(uuid.uuid4()), created.isoformat(), doc_name)
     return metadata

--- a/src/opossum_lib/merger.py
+++ b/src/opossum_lib/merger.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Dict, List
+
+from opossum_lib.opossum_file import (
+    OpossumInformation,
+    OpossumPackageIdentifier,
+    Resource,
+    ResourcePath,
+)
+
+
+def merge_opossum_information(
+    elements_to_merge: List[OpossumInformation],
+) -> OpossumInformation:
+    expanded_opossum_information = [
+        expand_opossum_package_identifier(opossum_information)
+        for opossum_information in elements_to_merge
+    ]
+    return OpossumInformation(
+        metadata=expanded_opossum_information[0].metadata,
+        resources=_merge_resources(
+            [
+                opossum_information.resources
+                for opossum_information in expanded_opossum_information
+            ]
+        ),
+        externalAttributions=_merge_dicts_without_duplicates(
+            [
+                opossum_information.externalAttributions
+                for opossum_information in expanded_opossum_information
+            ]
+        ),
+        resourcesToAttributions=_merge_resources_to_attributions(
+            [
+                opossum_information.resourcesToAttributions
+                for opossum_information in expanded_opossum_information
+            ]
+        ),
+        attributionBreakpoints=_merge_attribution_breakpoints(
+            [
+                opossum_information.attributionBreakpoints
+                for opossum_information in expanded_opossum_information
+            ]
+        ),
+        externalAttributionSources=_merge_dicts_without_duplicates(
+            [
+                opossum_information.externalAttributionSources
+                for opossum_information in expanded_opossum_information
+            ]
+        ),
+    )
+
+
+def expand_opossum_package_identifier(
+    opossum_information: OpossumInformation,
+) -> OpossumInformation:
+    """IDs for the attributions should be unique per OpossumInformation.
+    To prevent possible duplicates we add the projectId of the
+    OpossumInformation to the IDs as a prefix."""
+    prefix = opossum_information.metadata.projectId
+    extended_resources_to_attributions = dict()
+    for (
+        resource_path,
+        identifiers,
+    ) in opossum_information.resourcesToAttributions.items():
+        extended_resources_to_attributions[resource_path] = [
+            prefix + "-" + identifier for identifier in identifiers
+        ]
+    extended_external_attributions = dict()
+    for (
+        identifier,
+        external_attribution,
+    ) in opossum_information.externalAttributions.items():
+        extended_external_attributions[prefix + "-" + identifier] = external_attribution
+
+    return OpossumInformation(
+        metadata=opossum_information.metadata,
+        resources=opossum_information.resources,
+        externalAttributions=extended_external_attributions,
+        resourcesToAttributions=extended_resources_to_attributions,
+        attributionBreakpoints=opossum_information.attributionBreakpoints,
+        externalAttributionSources=opossum_information.externalAttributionSources,
+    )
+
+
+def _merge_resources(resources: List[Resource]) -> Resource:
+    merged_resource = Resource()
+    for resource in resources:
+        for resource_path in resource.get_paths():
+            merged_resource.add_path(resource_path.split("/")[1:-1])
+    return merged_resource
+
+
+def _merge_resources_to_attributions(
+    resources_to_attributions: List[Dict[ResourcePath, List[OpossumPackageIdentifier]]]
+) -> Dict[ResourcePath, List[OpossumPackageIdentifier]]:
+    merged_resources_to_attributions: Dict[
+        ResourcePath, List[OpossumPackageIdentifier]
+    ] = dict()
+    for resource_to_attribution in resources_to_attributions:
+        for resource_path, identifiers in resource_to_attribution.items():
+            identifiers_merged = merged_resources_to_attributions.get(resource_path, [])
+            identifiers_merged.extend(
+                [idf for idf in identifiers if idf not in identifiers_merged]
+            )
+            merged_resources_to_attributions[resource_path] = identifiers_merged
+
+    return merged_resources_to_attributions
+
+
+def _merge_attribution_breakpoints(
+    attribution_breakpoints_to_merge: List[List[str]],
+) -> List[str]:
+    merged_attribution_breakpoints = []
+    for attribution_breakpoints in attribution_breakpoints_to_merge:
+        merged_attribution_breakpoints.extend(
+            [
+                attribution_breakpoint
+                for attribution_breakpoint in attribution_breakpoints
+                if attribution_breakpoint not in merged_attribution_breakpoints
+            ]
+        )
+    return merged_attribution_breakpoints
+
+
+def _merge_dicts_without_duplicates(dicts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    merged_dict: Dict[str, Any] = dict()
+    for single_dict in dicts:
+        for key, value in single_dict.items():
+            if key in merged_dict and merged_dict.get(key) != value:
+                raise TypeError(
+                    "Couldn't merge and deduplicate: "
+                    "Values for identical keys don't match."
+                )
+            merged_dict.update({key: value})
+    return merged_dict

--- a/src/opossum_lib/opossum_file.py
+++ b/src/opossum_lib/opossum_file.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Union
 
 OpossumPackageIdentifier = str
+ResourcePath = str
 
 
 @dataclass(frozen=True)
@@ -14,10 +15,8 @@ class OpossumInformation:
     metadata: Metadata
     resources: Resource
     externalAttributions: Dict[OpossumPackageIdentifier, OpossumPackage]
-    resourcesToAttributions: Dict[
-        OpossumPackageIdentifier, List[OpossumPackageIdentifier]
-    ]
-    attributionBreakpoints: List[str]
+    resourcesToAttributions: Dict[ResourcePath, List[OpossumPackageIdentifier]]
+    attributionBreakpoints: List[str] = field(default_factory=list)
     externalAttributionSources: Dict[str, ExternalAttributionSource] = field(
         default_factory=dict
     )
@@ -80,6 +79,15 @@ class Resource:
             return {
                 name: resource.to_dict() for name, resource in self.children.items()
             }
+
+    def get_paths(self) -> List[str]:
+        if len(self.children) == 0:
+            return ["/"]
+        paths = []
+        for name, resource in self.children.items():
+            path = ["/" + name + path for path in resource.get_paths()]
+            paths.extend(path)
+        return paths
 
 
 @dataclass(frozen=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,10 @@ def test_cli_with_system_exit_code_0(tmp_path: Path, options: Tuple[str, str]) -
         with z.open("input.json") as file:
             opossum_dict = json.load(file)
     assert "metadata" in opossum_dict
+    # we are using randomly generated UUIDs for the project-id, therefore
+    # we need to exclude the "metadata" section from the comparison
+    opossum_dict.pop("metadata")
+    expected_opossum_dict.pop("metadata")
     assert opossum_dict == expected_opossum_dict
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase, mock
+
+import pytest
+
+from opossum_lib.merger import (
+    _merge_dicts_without_duplicates,
+    _merge_resources,
+    _merge_resources_to_attributions,
+    expand_opossum_package_identifier,
+    merge_opossum_information,
+)
+from opossum_lib.opossum_file import (
+    Metadata,
+    OpossumInformation,
+    OpossumPackage,
+    Resource,
+    SourceInfo,
+)
+
+
+@mock.patch("opossum_lib.opossum_file.OpossumPackage", autospec=True)
+def test_merge_opossum_information(opossum_package: OpossumPackage) -> None:
+    opossum_information = OpossumInformation(
+        Metadata("project-id", "30-05-2023", "test data"),
+        Resource({"A": Resource({"B": Resource({})})}),
+        {"SPDXRef-Package": opossum_package},
+        {"/A/B/": ["SPDXRef-Package"]},
+    )
+
+    opossum_information_2 = OpossumInformation(
+        Metadata("test-data-id", "29-05-2023", "second test data"),
+        Resource({"A": Resource({"D": Resource({"C": Resource({})})})}),
+        {"SPDXRef-File": opossum_package},
+        {"/A/D/C/": ["SPDXRef-File"]},
+    )
+
+    merged_information = merge_opossum_information(
+        [opossum_information, opossum_information_2]
+    )
+
+    assert merged_information.metadata == opossum_information.metadata
+    assert merged_information.resources == Resource(
+        {"A": Resource({"B": Resource({}), "D": Resource({"C": Resource({})})})}
+    )
+    assert merged_information.externalAttributions == {
+        "project-id-SPDXRef-Package": opossum_package,
+        "test-data-id-SPDXRef-File": opossum_package,
+    }
+    assert merged_information.resourcesToAttributions == {
+        "/A/B/": ["project-id-SPDXRef-Package"],
+        "/A/D/C/": ["test-data-id-SPDXRef-File"],
+    }
+
+
+def test_merge_resources() -> None:
+    list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    resource = Resource()
+
+    for path in list_of_paths:
+        resource.add_path(path)
+    list_of_paths = [["C", "D", "E"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    resource2 = Resource()
+
+    for path in list_of_paths:
+        resource2.add_path(path)
+    resources = [resource, resource2]
+    merged_resource = _merge_resources(resources)
+
+    assert merged_resource == Resource(
+        {
+            "A": Resource({"B": Resource({"C": Resource({})}), "D": Resource({})}),
+            "C": Resource({"D": Resource({"E": Resource({})})}),
+        }
+    )
+
+
+def test_merge_resources_to_attributions() -> None:
+    resources_to_attributions = [
+        {"resources/Path": ["identifier-A", "identifier-B"]},
+        {"resources/Path": ["identifier-C"]},
+        {"resources/Path/different": ["identifier-A"]},
+    ]
+    resources_to_attribution = _merge_resources_to_attributions(
+        resources_to_attributions
+    )
+
+    assert "resources/Path" in resources_to_attribution
+    TestCase().assertCountEqual(
+        resources_to_attribution["resources/Path"],
+        ["identifier-A", "identifier-B", "identifier-C"],
+    )
+    assert "resources/Path/different" in resources_to_attribution
+    assert resources_to_attribution["resources/Path/different"] == ["identifier-A"]
+
+
+@mock.patch("opossum_lib.opossum_file.OpossumPackage", autospec=True)
+def test_merge_dicts_without_duplicates(opossum_package: OpossumPackage) -> None:
+    dicts = [{"A": opossum_package}, {"B": opossum_package}]
+    merged_dict = _merge_dicts_without_duplicates(dicts)
+
+    assert merged_dict == {"A": opossum_package, "B": opossum_package}
+
+
+@mock.patch("opossum_lib.opossum_file.SourceInfo", autospec=True)
+def test_merge_dicts_without_duplicates_type_error(
+    source_info: SourceInfo,
+) -> None:
+    dicts = [
+        {"A": OpossumPackage(source_info, comment="test package 1")},
+        {"A": OpossumPackage(source_info, comment="test package 2")},
+    ]
+    with pytest.raises(TypeError):
+        _merge_dicts_without_duplicates(dicts)
+
+
+@mock.patch("opossum_lib.opossum_file.Resource")
+@mock.patch("opossum_lib.opossum_file.OpossumPackage")
+def test_expand_opossum_package_identifier(
+    opossum_package: OpossumPackage, resource: Resource
+) -> None:
+    opossum_information_expanded = expand_opossum_package_identifier(
+        OpossumInformation(
+            Metadata("project-id", "2022-03-02", "project title"),
+            resources=resource,
+            externalAttributions={"SPDXRef-Package": opossum_package},
+            resourcesToAttributions={"/path/to/resource": ["SPDXRef-Package"]},
+            attributionBreakpoints=[],
+            externalAttributionSources={},
+        )
+    )
+
+    assert opossum_information_expanded.resourcesToAttributions == {
+        "/path/to/resource": ["project-id-SPDXRef-Package"]
+    }
+    assert opossum_information_expanded.externalAttributions == {
+        "project-id-SPDXRef-Package": opossum_package
+    }

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -12,3 +12,13 @@ def test_resource_to_dict() -> None:
         resource.add_path(path)
 
     assert resource.to_dict() == {"A": {"B": {"C": 1}, "D": 1}}
+
+
+def test_resource_get_path() -> None:
+    list_of_paths = [["A", "B", "C"], ["A", "D"], ["D", "E", "F"]]
+    resource = Resource()
+
+    for path in list_of_paths:
+        resource.add_path(path)
+
+    assert resource.get_paths() == ["/A/B/C/", "/A/D/", "/D/E/F/"]


### PR DESCRIPTION
This PR adds a method to merge multiple opossum datastructures. 

In the description of the ticket we said that we want to raise an error if there is a name clash between file and folder when merging resources. So far the implementation doesn't distinguish between file and folder, every leaf in the resource tree is a file. I opened an issue to implement this which should then also take care of the merge functionality (#60).

I decided to implement merge functionalities for all fields currently present in the `OpossumInformation` class. All based on the same principle: merge and deduplicate.
Additionally, I decided to expand the internal IDs for the attributions with the project-id to make them unique per document. As we previously used identical ids for the project I had to adapt the implementation to use UUIDs for the projectID.
 
fixes #46 