### PR TITLE
Add missing output file handling

### DIFF
--- a/src/opossum_lib/cli.py
+++ b/src/opossum_lib/cli.py
@@ -31,6 +31,8 @@ from opossum_lib.tree_generation import generate_tree_from_graph
 @click.option(
     "--outfile",
     "-o",
+    default="output.opossum",
+    show_default=True,
     help="The file path to write the generated opossum document to. The generated file "
     "will be an opossum file, if the specified file path doesn't match this file "
     'extension ".opossum" will be appended.',
@@ -63,6 +65,10 @@ def spdx2opossum(infile: str, outfile: str) -> None:
 
     if not outfile.endswith(".opossum"):
         outfile += ".opossum"
+
+    if Path.is_file(Path(outfile)):
+        logging.warning(f"{outfile} already exists and will be overwritten.")
+
     write_dict_to_file(opossum_information, Path(outfile))
 
 

--- a/tests/helper_methods.py
+++ b/tests/helper_methods.py
@@ -36,7 +36,9 @@ def _create_minimal_document() -> Document:
     file = File(
         name="Example file",
         spdx_id="SPDXRef-File",
-        checksums=[Checksum(ChecksumAlgorithm.SHA1, "")],
+        checksums=[
+            Checksum(ChecksumAlgorithm.SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
+        ],
     )
 
     relationships = [


### PR DESCRIPTION
### Summary of Changes

Set a default output file in case no file path is provided. 

### Context and Reasons for Changes

We want to enable the user to leave out the output file and write to a default file.

Fix: #56 