### PR TITLE
[issue-60] distinguish file and folder in resource tree

### DIFF
--- a/src/opossum_lib/helper_methods.py
+++ b/src/opossum_lib/helper_methods.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
 from typing import List, Optional
 
 from networkx import DiGraph, weakly_connected_components

--- a/src/opossum_lib/helper_methods.py
+++ b/src/opossum_lib/helper_methods.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import List, Optional
 
 from networkx import DiGraph, weakly_connected_components
@@ -68,3 +70,7 @@ def _replace_prefix(label: str) -> str:
     elif label.startswith("/"):
         return label[1:]
     return label
+
+
+def is_leaf_element(child_elements: List[str]) -> bool:
+    return len(child_elements) == 0

--- a/src/opossum_lib/helper_methods.py
+++ b/src/opossum_lib/helper_methods.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from networkx import DiGraph, weakly_connected_components
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
+from spdx_tools.spdx.model import File, Package, Snippet
+
+from opossum_lib.opossum_file import ResourceType
 
 
 def _get_source_for_graph_traversal(connected_subgraph: DiGraph) -> Optional[str]:
@@ -47,12 +50,24 @@ def _create_file_path_from_graph_path(path: List[str], graph: DiGraph) -> str:
     return base_path
 
 
-def _replace_node_ids_with_labels(path: List[str], graph: DiGraph) -> List[str]:
+def _replace_node_ids_with_labels_and_add_resource_type(
+    path: List[str], graph: DiGraph
+) -> List[Tuple[str, ResourceType]]:
     resulting_path = []
-    path_with_label = [_replace_prefix(graph.nodes[node]["label"]) for node in path]
-    for element_or_path in path_with_label:
+    path_with_label_and_resource_type = [
+        (
+            _replace_prefix(graph.nodes[node]["label"]),
+            _get_resource_type(graph.nodes[node]),
+        )
+        for node in path
+    ]
+    for element_or_path, resource_type in path_with_label_and_resource_type:
         resulting_path.extend(
-            [element for element in element_or_path.split("/") if element]
+            [
+                (element, resource_type)
+                for element in element_or_path.split("/")
+                if element
+            ]
         )
 
     return resulting_path
@@ -70,5 +85,11 @@ def _replace_prefix(label: str) -> str:
     return label
 
 
-def is_leaf_element(child_elements: List[str]) -> bool:
-    return len(child_elements) == 0
+def _get_resource_type(node_attributes: Dict[str, Any]) -> ResourceType:
+    element = node_attributes.get("element", None)
+    if isinstance(element, Package):
+        return ResourceType.FOLDER
+    elif isinstance(element, (Snippet, File)):
+        return ResourceType.FILE
+    else:
+        return ResourceType.OTHER

--- a/src/opossum_lib/merger.py
+++ b/src/opossum_lib/merger.py
@@ -8,6 +8,7 @@ from opossum_lib.opossum_file import (
     OpossumPackageIdentifier,
     Resource,
     ResourcePath,
+    ResourceType,
 )
 
 
@@ -86,10 +87,12 @@ def expand_opossum_package_identifier(
 
 
 def _merge_resources(resources: List[Resource]) -> Resource:
-    merged_resource = Resource()
+    merged_resource = Resource(ResourceType.TOP_LEVEL)
     for resource in resources:
-        for resource_path in resource.get_paths():
-            merged_resource.add_path(resource_path.split("/")[1:-1])
+        for resource_path, type_of_last_element in resource.get_paths():
+            merged_resource.add_path(
+                resource_path.split("/")[1:-1], type_of_last_element
+            )
     return merged_resource
 
 

--- a/src/opossum_lib/merger.py
+++ b/src/opossum_lib/merger.py
@@ -89,9 +89,10 @@ def expand_opossum_package_identifier(
 def _merge_resources(resources: List[Resource]) -> Resource:
     merged_resource = Resource(ResourceType.TOP_LEVEL)
     for resource in resources:
-        for resource_path, type_of_last_element in resource.get_paths():
+        for resource_path, resource_type in resource.get_paths_with_resource_types():
             merged_resource.add_path(
-                resource_path.split("/")[1:-1], type_of_last_element
+                [element for element in resource_path.split("/") if element],
+                resource_type,
             )
     return merged_resource
 

--- a/src/opossum_lib/merger.py
+++ b/src/opossum_lib/merger.py
@@ -89,11 +89,8 @@ def expand_opossum_package_identifier(
 def _merge_resources(resources: List[Resource]) -> Resource:
     merged_resource = Resource(ResourceType.TOP_LEVEL)
     for resource in resources:
-        for resource_path, resource_type in resource.get_paths_with_resource_types():
-            merged_resource.add_path(
-                [element for element in resource_path.split("/") if element],
-                resource_type,
-            )
+        for path in resource.get_paths_with_resource_types():
+            merged_resource.add_path(path)
     return merged_resource
 
 

--- a/src/opossum_lib/opossum_file.py
+++ b/src/opossum_lib/opossum_file.py
@@ -92,10 +92,10 @@ class Resource:
         self.children[first].add_path(rest)
 
     def element_exists_but_resource_type_differs(
-        self, element: str, type_of_last_element: ResourceType
+        self, element: str, resource_type: ResourceType
     ) -> bool:
         if element in self.children:
-            return self.children[element].type != type_of_last_element
+            return self.children[element].type != resource_type
         return False
 
     def to_dict(self) -> Union[int, Dict]:

--- a/tests/data/expected_opossum.json
+++ b/tests/data/expected_opossum.json
@@ -20,7 +20,7 @@
             }
           }
         },
-        "Package B":1
+        "Package B":{}
       }
     },
     "SPDXRef-Snippet":1

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -34,7 +34,7 @@ def test_different_paths_graph() -> None:
         }
     }
     document = _create_minimal_document()
-    opossum_information = document_to_opossum_information(document)
+    opossum_information = _get_opossum_information_from_document(document)
 
     file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
@@ -98,7 +98,7 @@ def test_unconnected_paths_graph() -> None:
             download_location="https://download.location.com",
         )
     ]
-    opossum_information = document_to_opossum_information(document)
+    opossum_information = _get_opossum_information_from_document(document)
 
     file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
@@ -147,7 +147,7 @@ def test_different_roots_graph() -> None:
         },
     }
     document = _generate_document_with_from_root_node_unreachable_file()
-    opossum_information = document_to_opossum_information(document)
+    opossum_information = _get_opossum_information_from_document(document)
 
     file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
@@ -182,7 +182,7 @@ def test_different_roots_graph() -> None:
 
 
 def test_tree_generation_for_bigger_examples_json() -> None:
-    opossum_information = file_name_to_opossum_information(
+    opossum_information = _get_opossum_information_from_file(
         "SPDXJSONExample-v2.3.spdx.json"
     )
     file_tree = opossum_information.resources.to_dict()
@@ -211,7 +211,7 @@ def test_tree_generation_for_bigger_examples_json() -> None:
 
 
 def test_tree_generation_for_bigger_examples_spdx() -> None:
-    opossum_information = file_name_to_opossum_information("SPDX.spdx")
+    opossum_information = _get_opossum_information_from_file("SPDX.spdx")
     file_tree = opossum_information.resources.to_dict()
     expected_breakpoints = [
         "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
@@ -232,12 +232,12 @@ def test_tree_generation_for_bigger_examples_spdx() -> None:
     )
 
 
-def file_name_to_opossum_information(file_name: str) -> OpossumInformation:
+def _get_opossum_information_from_file(file_name: str) -> OpossumInformation:
     document = parse_file(str(Path(__file__).resolve().parent / "data" / file_name))
-    return document_to_opossum_information(document)
+    return _get_opossum_information_from_document(document)
 
 
-def document_to_opossum_information(document: Document) -> OpossumInformation:
+def _get_opossum_information_from_document(document: Document) -> OpossumInformation:
     graph = generate_graph_from_spdx(document)
     tree = generate_tree_from_graph(graph)
     opossum_information = generate_json_file_from_tree(tree)

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
-from typing import List
 from unittest import TestCase
 
-import pytest
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.parser.parse_anything import parse_file
 
@@ -16,7 +15,7 @@ from opossum_lib.constants import (
 )
 from opossum_lib.file_generation import generate_json_file_from_tree
 from opossum_lib.graph_generation import generate_graph_from_spdx
-from opossum_lib.opossum_file import ExternalAttributionSource
+from opossum_lib.opossum_file import ExternalAttributionSource, OpossumInformation
 from opossum_lib.tree_generation import generate_tree_from_graph
 from tests.helper_methods import (
     _create_minimal_document,
@@ -35,11 +34,7 @@ def test_different_paths_graph() -> None:
         }
     }
     document = _create_minimal_document()
-
-    graph = generate_graph_from_spdx(document)
-    tree = generate_tree_from_graph(graph)
-
-    opossum_information = generate_json_file_from_tree(tree)
+    opossum_information = document_to_opossum_information(document)
 
     file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
@@ -103,11 +98,7 @@ def test_unconnected_paths_graph() -> None:
             download_location="https://download.location.com",
         )
     ]
-
-    graph = generate_graph_from_spdx(document)
-    tree = generate_tree_from_graph(graph)
-
-    opossum_information = generate_json_file_from_tree(tree)
+    opossum_information = document_to_opossum_information(document)
 
     file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
@@ -156,10 +147,7 @@ def test_different_roots_graph() -> None:
         },
     }
     document = _generate_document_with_from_root_node_unreachable_file()
-
-    graph = generate_graph_from_spdx(document)
-    tree = generate_tree_from_graph(graph)
-    opossum_information = generate_json_file_from_tree(tree)
+    opossum_information = document_to_opossum_information(document)
 
     file_tree = opossum_information.resources.to_dict()
     assert file_tree == expected_file_tree
@@ -193,42 +181,64 @@ def test_different_roots_graph() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "file_name, expected_top_level_keys, expected_breakpoints",
-    [
-        (
-            "SPDXJSONExample-v2.3.spdx.json",
-            3,
-            [
-                "/SPDX-Tools-v2.0/CONTAINS/glibc/CONTAINS/"
-                "lib-source/commons-lang3-3.1-sources.jar/GENERATED_FROM/",
-                "/SPDX-Tools-v2.0/CONTAINS/glibc/DYNAMIC_LINK/",
-            ],
-        ),
-        (
-            "SPDX.spdx",
-            2,
-            [
-                "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
-                "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/"
-                "Package C/CONTAINS/",
-            ],
-        ),
-    ],
-)
-def test_tree_generation_for_bigger_examples(
-    file_name: str,
-    expected_top_level_keys: int,
-    expected_breakpoints: List[str],
-) -> None:
-    document = parse_file(str(Path(__file__).resolve().parent / "data" / file_name))
-    graph = generate_graph_from_spdx(document)
-    tree = generate_tree_from_graph(graph)
-    opossum_information = generate_json_file_from_tree(tree)
-
+def test_tree_generation_for_bigger_examples_json() -> None:
+    opossum_information = file_name_to_opossum_information(
+        "SPDXJSONExample-v2.3.spdx.json"
+    )
     file_tree = opossum_information.resources.to_dict()
+
+    expected_breakpoints = [
+        "/SPDX-Tools-v2.0/CONTAINS/glibc/CONTAINS/"
+        "lib-source/commons-lang3-3.1-sources.jar/GENERATED_FROM/",
+        "/SPDX-Tools-v2.0/CONTAINS/glibc/DYNAMIC_LINK/",
+    ]
+
     assert isinstance(file_tree, dict)
-    assert len(file_tree.keys()) == expected_top_level_keys
+    assert len(file_tree.keys()) == 3
 
     for attribution_breakpoint in expected_breakpoints:
         assert attribution_breakpoint in opossum_information.attributionBreakpoints
+    assert (
+        file_tree["SPDX-Tools-v2.0"]["COPY_OF"][
+            "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+        ]
+        == 1
+    )
+
+    assert (
+        file_tree["SPDX-Tools-v2.0"]["CONTAINS"]["glibc"]["DYNAMIC_LINK"]["Saxon"] == {}
+    )
+
+
+def test_tree_generation_for_bigger_examples_spdx() -> None:
+    opossum_information = file_name_to_opossum_information("SPDX.spdx")
+    file_tree = opossum_information.resources.to_dict()
+    expected_breakpoints = [
+        "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/",
+        "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/" "Package C/CONTAINS/",
+    ]
+
+    assert isinstance(file_tree, dict)
+    assert len(file_tree.keys()) == 2
+
+    for attribution_breakpoint in expected_breakpoints:
+        assert attribution_breakpoint in opossum_information.attributionBreakpoints
+
+    assert file_tree["SPDX Lite Document"]["DESCRIBES"]["Package B"] == {}
+
+    assert (
+        file_tree["SPDX Lite Document"]["DESCRIBES"]["Package A"]["CONTAINS"]["File-C"]
+        == 1
+    )
+
+
+def file_name_to_opossum_information(file_name: str) -> OpossumInformation:
+    document = parse_file(str(Path(__file__).resolve().parent / "data" / file_name))
+    return document_to_opossum_information(document)
+
+
+def document_to_opossum_information(document: Document) -> OpossumInformation:
+    graph = generate_graph_from_spdx(document)
+    tree = generate_tree_from_graph(graph)
+    opossum_information = generate_json_file_from_tree(tree)
+    return opossum_information

--- a/tests/test_helper_methods.py
+++ b/tests/test_helper_methods.py
@@ -8,8 +8,9 @@ from networkx import DiGraph
 
 from opossum_lib.helper_methods import (
     _create_file_path_from_graph_path,
-    _replace_node_ids_with_labels,
+    _replace_node_ids_with_labels_and_add_resource_type,
 )
+from opossum_lib.opossum_file import ResourceType
 
 
 @pytest.mark.parametrize(
@@ -31,9 +32,18 @@ def test_replace_node_ids_with_labels(node_label: str) -> None:
     graph = _create_simple_graph(node_label)
     path = ["root", "node", "leaf"]
 
-    file_path = _replace_node_ids_with_labels(path, graph)
+    file_path = _replace_node_ids_with_labels_and_add_resource_type(path, graph)
 
-    TestCase().assertCountEqual(file_path, ["root", "node", "with", "path", "leaf"])
+    TestCase().assertCountEqual(
+        file_path,
+        [
+            ("root", ResourceType.OTHER),
+            ("node", ResourceType.OTHER),
+            ("with", ResourceType.OTHER),
+            ("path", ResourceType.OTHER),
+            ("leaf", ResourceType.OTHER),
+        ],
+    )
 
 
 def _create_simple_graph(node_label: str) -> DiGraph:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -51,7 +51,7 @@ def test_merge_opossum_information(opossum_package: OpossumPackage) -> None:
                     {
                         "D": Resource(
                             ResourceType.FOLDER,
-                            {"C": Resource(ResourceType.FOLDER, {})},
+                            {"C": Resource(ResourceType.FILE, {})},
                         )
                     },
                 )
@@ -74,7 +74,7 @@ def test_merge_opossum_information(opossum_package: OpossumPackage) -> None:
                 {
                     "B": Resource(ResourceType.FOLDER, {}),
                     "D": Resource(
-                        ResourceType.FOLDER, {"C": Resource(ResourceType.FOLDER, {})}
+                        ResourceType.FOLDER, {"C": Resource(ResourceType.FILE, {})}
                     ),
                 },
             )
@@ -91,16 +91,26 @@ def test_merge_opossum_information(opossum_package: OpossumPackage) -> None:
 
 
 def test_merge_resources() -> None:
-    list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    list_of_paths_with_resource_types = [
+        (["A"], ResourceType.FOLDER),
+        (["A", "B", "C"], ResourceType.FILE),
+        (["A", "B"], ResourceType.FOLDER),
+        (["A", "D"], ResourceType.FILE),
+    ]
     resource = Resource(ResourceType.TOP_LEVEL)
 
-    for path in list_of_paths:
-        resource.add_path(path, ResourceType.FOLDER)
-    list_of_paths = [["C", "D", "E"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    for path, resource_type in list_of_paths_with_resource_types:
+        resource.add_path(path, resource_type)
+    list_of_paths_with_resource_type = [
+        (["C", "D", "E"], ResourceType.FOLDER),
+        (["A", "B", "C"], ResourceType.FILE),
+        (["A", "B"], ResourceType.FOLDER),
+        (["A", "D"], ResourceType.FILE),
+    ]
     resource2 = Resource(ResourceType.TOP_LEVEL)
 
-    for path in list_of_paths:
-        resource2.add_path(path, ResourceType.FOLDER)
+    for path, resource_type in list_of_paths_with_resource_type:
+        resource2.add_path(path, resource_type)
     resources = [resource, resource2]
     merged_resource = _merge_resources(resources)
 
@@ -111,9 +121,9 @@ def test_merge_resources() -> None:
                 ResourceType.FOLDER,
                 {
                     "B": Resource(
-                        ResourceType.FOLDER, {"C": Resource(ResourceType.FOLDER, {})}
+                        ResourceType.FOLDER, {"C": Resource(ResourceType.FILE, {})}
                     ),
-                    "D": Resource(ResourceType.FOLDER, {}),
+                    "D": Resource(ResourceType.FILE, {}),
                 },
             ),
             "C": Resource(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -92,24 +92,36 @@ def test_merge_opossum_information(opossum_package: OpossumPackage) -> None:
 
 def test_merge_resources() -> None:
     list_of_paths_with_resource_types = [
-        (["A"], ResourceType.FOLDER),
-        (["A", "B", "C"], ResourceType.FILE),
-        (["A", "B"], ResourceType.FOLDER),
-        (["A", "D"], ResourceType.FILE),
+        [("A", ResourceType.FOLDER)],
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FOLDER),
+            ("C", ResourceType.FILE),
+        ],
+        [("A", ResourceType.FOLDER), ("D", ResourceType.FILE)],
     ]
+
     resource = Resource(ResourceType.TOP_LEVEL)
-    for path, resource_type in list_of_paths_with_resource_types:
-        resource.add_path(path, resource_type)
+    for path in list_of_paths_with_resource_types:
+        resource.add_path(path)
 
     list_of_paths_with_resource_type = [
-        (["C", "D", "E"], ResourceType.FOLDER),
-        (["A", "B", "C"], ResourceType.FILE),
-        (["A", "B"], ResourceType.FOLDER),
-        (["A", "D"], ResourceType.FILE),
+        [("A", ResourceType.FOLDER)],
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FOLDER),
+            ("C", ResourceType.FILE),
+        ],
+        [("A", ResourceType.FOLDER), ("D", ResourceType.FILE)],
+        [
+            ("C", ResourceType.FOLDER),
+            ("D", ResourceType.FOLDER),
+            ("E", ResourceType.FOLDER),
+        ],
     ]
     resource2 = Resource(ResourceType.TOP_LEVEL)
-    for path, resource_type in list_of_paths_with_resource_type:
-        resource2.add_path(path, resource_type)
+    for path in list_of_paths_with_resource_type:
+        resource2.add_path(path)
 
     resources = [resource, resource2]
     merged_resource = _merge_resources(resources)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -98,9 +98,9 @@ def test_merge_resources() -> None:
         (["A", "D"], ResourceType.FILE),
     ]
     resource = Resource(ResourceType.TOP_LEVEL)
-
     for path, resource_type in list_of_paths_with_resource_types:
         resource.add_path(path, resource_type)
+
     list_of_paths_with_resource_type = [
         (["C", "D", "E"], ResourceType.FOLDER),
         (["A", "B", "C"], ResourceType.FILE),
@@ -108,9 +108,9 @@ def test_merge_resources() -> None:
         (["A", "D"], ResourceType.FILE),
     ]
     resource2 = Resource(ResourceType.TOP_LEVEL)
-
     for path, resource_type in list_of_paths_with_resource_type:
         resource2.add_path(path, resource_type)
+
     resources = [resource, resource2]
     merged_resource = _merge_resources(resources)
 

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
+import pytest
+
 from opossum_lib.opossum_file import Resource, ResourceType
 
 
@@ -35,8 +37,16 @@ def test_resource_get_path() -> None:
     for path, resource_type in list_of_paths:
         resource.add_path(path, resource_type)
 
-    assert resource.get_paths() == [
+    assert resource.get_paths_with_resource_types() == [
         ("/A/B/C/", ResourceType.FOLDER),
         ("/A/D", ResourceType.FILE),
         ("/D/E/F", ResourceType.OTHER),
     ]
+
+
+def test_resource_add_path_type_error() -> None:
+    resource = Resource(ResourceType.TOP_LEVEL)
+    resource.add_path(["A", "B", "C"], ResourceType.FOLDER)
+
+    with pytest.raises(TypeError):
+        resource.add_path(["A", "B", "C"], ResourceType.FILE)

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -44,7 +44,9 @@ def test_resource_get_path() -> None:
     ]
 
 
-def test_resource_add_path_type_error() -> None:
+def test_resource_add_path_throws_err_if_leaf_element_exists_with_different_type() -> (
+    None
+):
     resource = Resource(ResourceType.TOP_LEVEL)
     resource.add_path(["A", "B", "C"], ResourceType.FOLDER)
 

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -7,40 +7,80 @@ from opossum_lib.opossum_file import Resource, ResourceType
 
 
 def test_resource_to_dict_with_file_as_leaf() -> None:
-    list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    list_of_paths = [
+        [("A", ResourceType.FOLDER)],
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FILE),
+            ("C", ResourceType.FILE),
+        ],
+        [("A", ResourceType.FOLDER), ("B", ResourceType.FILE)],
+        [("A", ResourceType.FOLDER), ("D", ResourceType.FILE)],
+    ]
     resource = Resource(ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
-        resource.add_path(path, ResourceType.FILE)
+        resource.add_path(path)
 
     assert resource.to_dict() == {"A": {"B": {"C": 1}, "D": 1}}
 
 
 def test_resource_to_dict_with_package_as_leaf() -> None:
-    list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    list_of_paths = [
+        [("A", ResourceType.FOLDER)],
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FILE),
+            ("C", ResourceType.FOLDER),
+        ],
+        [("A", ResourceType.FOLDER), ("B", ResourceType.FILE)],
+        [("A", ResourceType.FOLDER), ("D", ResourceType.FOLDER)],
+    ]
     resource = Resource(ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
-        resource.add_path(path, ResourceType.FOLDER)
+        resource.add_path(path)
 
     assert resource.to_dict() == {"A": {"B": {"C": {}}, "D": {}}}
 
 
 def test_resource_get_path() -> None:
     list_of_paths = [
-        (["A", "B", "C"], ResourceType.FOLDER),
-        (["A", "D"], ResourceType.FILE),
-        (["D", "E", "F"], ResourceType.OTHER),
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FILE),
+            ("C", ResourceType.FOLDER),
+        ],
+        [
+            ("A", ResourceType.FOLDER),
+            ("D", ResourceType.FILE),
+        ],
+        [
+            ("D", ResourceType.FOLDER),
+            ("E", ResourceType.FILE),
+            ("F", ResourceType.OTHER),
+        ],
     ]
     resource = Resource(ResourceType.TOP_LEVEL)
 
-    for path, resource_type in list_of_paths:
-        resource.add_path(path, resource_type)
+    for path in list_of_paths:
+        resource.add_path(path)
 
     assert resource.get_paths_with_resource_types() == [
-        ("/A/B/C/", ResourceType.FOLDER),
-        ("/A/D", ResourceType.FILE),
-        ("/D/E/F", ResourceType.OTHER),
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FILE),
+            ("C", ResourceType.FOLDER),
+        ],
+        [
+            ("A", ResourceType.FOLDER),
+            ("D", ResourceType.FILE),
+        ],
+        [
+            ("D", ResourceType.FOLDER),
+            ("E", ResourceType.FILE),
+            ("F", ResourceType.OTHER),
+        ],
     ]
 
 
@@ -48,7 +88,40 @@ def test_resource_add_path_throws_err_if_leaf_element_exists_with_different_type
     None
 ):
     resource = Resource(ResourceType.TOP_LEVEL)
-    resource.add_path(["A", "B", "C"], ResourceType.FOLDER)
+    resource.add_path(
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FILE),
+            ("C", ResourceType.FOLDER),
+        ]
+    )
 
     with pytest.raises(TypeError):
-        resource.add_path(["A", "B", "C"], ResourceType.FILE)
+        resource.add_path(
+            [
+                ("A", ResourceType.FOLDER),
+                ("B", ResourceType.FILE),
+                ("C", ResourceType.FILE),
+            ]
+        )
+
+
+def test_resource_add_path_throws_err_if_element_exists_with_different_type() -> None:
+    resource = Resource(ResourceType.TOP_LEVEL)
+    resource.add_path(
+        [
+            ("A", ResourceType.FOLDER),
+            ("B", ResourceType.FILE),
+            ("C", ResourceType.FOLDER),
+            ("D", ResourceType.FILE),
+        ]
+    )
+
+    with pytest.raises(TypeError):
+        resource.add_path(
+            [
+                ("A", ResourceType.FOLDER),
+                ("B", ResourceType.FILE),
+                ("C", ResourceType.FILE),
+            ]
+        )

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -1,24 +1,42 @@
 # SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from opossum_lib.opossum_file import Resource
+from opossum_lib.opossum_file import Resource, ResourceType
 
 
-def test_resource_to_dict() -> None:
+def test_resource_to_dict_with_file_as_leaf() -> None:
     list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
-    resource = Resource()
+    resource = Resource(ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
-        resource.add_path(path)
+        resource.add_path(path, ResourceType.FILE)
 
     assert resource.to_dict() == {"A": {"B": {"C": 1}, "D": 1}}
 
 
-def test_resource_get_path() -> None:
-    list_of_paths = [["A", "B", "C"], ["A", "D"], ["D", "E", "F"]]
-    resource = Resource()
+def test_resource_to_dict_with_package_as_leaf() -> None:
+    list_of_paths = [["A"], ["A", "B", "C"], ["A", "B"], ["A", "D"]]
+    resource = Resource(ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
-        resource.add_path(path)
+        resource.add_path(path, ResourceType.FOLDER)
 
-    assert resource.get_paths() == ["/A/B/C/", "/A/D/", "/D/E/F/"]
+    assert resource.to_dict() == {"A": {"B": {"C": {}}, "D": {}}}
+
+
+def test_resource_get_path() -> None:
+    list_of_paths = [
+        (["A", "B", "C"], ResourceType.FOLDER),
+        (["A", "D"], ResourceType.FILE),
+        (["D", "E", "F"], ResourceType.OTHER),
+    ]
+    resource = Resource(ResourceType.TOP_LEVEL)
+
+    for path, resource_type in list_of_paths:
+        resource.add_path(path, resource_type)
+
+    assert resource.get_paths() == [
+        ("/A/B/C/", ResourceType.FOLDER),
+        ("/A/D", ResourceType.FILE),
+        ("/D/E/F", ResourceType.OTHER),
+    ]


### PR DESCRIPTION
To be able to distinguish files and folder in the resource tree this PR adds a type to the Resource class. When a new element is added to the opossum datastructure the corresponding path is added to the resources with the corresponding ResourceType. Files and snippets get the type FILE, packages FOLDER, the top-level Resource TOP_LEVEL and all other attributions get the type OTHER. Elements within the path get the type FOLDER if they are not yet part of the resource tree. 

I had to delete some parts of the `test_tree_generation_for_bigger_examples` as the introduced changes now result in different expected values (`1` or `{}`) for file paths which doesn't fit with the parametrized tests. As we have other unit tests to verifiy the correctness of the resource tree, I don't think that this is an issue.
 
fixes #60