### PR TITLE
[hot-fix] don't cancel matrix jobs if one job fails

### DIFF
--- a/.github/workflows/lint_and_run_tests.yml
+++ b/.github/workflows/lint_and_run_tests.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
   workflow_dispatch:
 
+
 jobs:
   linter:
     runs-on: ${{ matrix.os }}
@@ -17,6 +18,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
@@ -73,6 +75,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]


### PR DESCRIPTION
Disable the fail-fast strategy on matrix elements to ensure that the jobs for ubuntu are run even if the ones for windows or mac fail.

This is a hot fix for issue #69.