### PR TITLE
Update spdx-tools

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -594,13 +594,13 @@ files = [
 
 [[package]]
 name = "spdx-tools"
-version = "0.8.1"
+version = "0.8.2"
 description = "SPDX parser and tools."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "spdx-tools-0.8.1.tar.gz", hash = "sha256:c83652cd65b5726058dcbdaab85839dbe484c43ea6f61046137516aa1b8428ae"},
-    {file = "spdx_tools-0.8.1-py3-none-any.whl", hash = "sha256:84eb4e524d2020da6120f19eab2e4ab1bb4e08453037ebe689159f74f7058684"},
+    {file = "spdx-tools-0.8.2.tar.gz", hash = "sha256:aea4ac9c2c375e7f439b1cef5ff32ef34914c083de0f61e08ed67cd3d9deb2a9"},
+    {file = "spdx_tools-0.8.2-py3-none-any.whl", hash = "sha256:8c336c873f9caaf110693a1d38c007031e67bea53aa4b881007b680be66de934"},
 ]
 
 [package.dependencies]
@@ -618,7 +618,7 @@ xmltodict = "*"
 code-style = ["black", "flake8", "isort"]
 development = ["black", "flake8", "isort", "networkx", "pytest"]
 graph-generation = ["networkx", "pygraphviz"]
-test = ["pyshacl", "pytest"]
+test = ["pyshacl", "pytest", "tzdata"]
 
 [[package]]
 name = "tomli"
@@ -687,4 +687,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "b7cd1062c44dd6dab33a8723f49ac17821c3cc8caa9e998ea2982b022c4c98b1"
+content-hash = "ecbe578942540ea0a20d985a277f9140e7d85f0fc2f7aec3e47f3f5949a422cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ spdx2opossum = 'opossum_lib.cli:spdx2opossum'
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-spdx-tools = "^0.8.1"
+spdx-tools = "^0.8.2"
 networkx = "^3.0"
 click = "^8.1.7"
 pre-commit = "^3.4.0"

--- a/tests/data/SPDX.spdx
+++ b/tests/data/SPDX.spdx
@@ -13,7 +13,7 @@ Created: 2023-03-14T08:49:00Z
 PackageName: Package A
 SPDXID: SPDXRef-Package-A
 PackageDownloadLocation: https://download.com
-FilesAnalyzed: True
+FilesAnalyzed: true
 
 ## File Information
 FileName: File-A
@@ -29,13 +29,13 @@ FileChecksum: SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
 PackageName: Package B
 SPDXID: SPDXRef-Package-B
 PackageDownloadLocation: https://download.com
-FilesAnalyzed: True
+FilesAnalyzed: true
 
 ## Package Information
 PackageName: Package C
 SPDXID: SPDXRef-Package-C
 PackageDownloadLocation: https://download.com
-FilesAnalyzed: True
+FilesAnalyzed: true
 
 ## File Information
 FileName: File-B

--- a/tests/data/expected_opossum.json
+++ b/tests/data/expected_opossum.json
@@ -40,7 +40,7 @@
         "name":"SPDX-Package",
         "documentConfidence":0
       },
-      "comment":"## Package Information\nPackageName: Package A\nSPDXID: SPDXRef-Package-A\nPackageDownloadLocation: https://download.com\nFilesAnalyzed: True\n",
+      "comment":"## Package Information\nPackageName: Package A\nSPDXID: SPDXRef-Package-A\nPackageDownloadLocation: https://download.com\nFilesAnalyzed: true\n",
       "packageName":"Package A",
       "copyright":"None",
       "licenseName":"None",
@@ -51,7 +51,7 @@
         "name":"SPDX-Package",
         "documentConfidence":0
       },
-      "comment":"## Package Information\nPackageName: Package B\nSPDXID: SPDXRef-Package-B\nPackageDownloadLocation: https://download.com\nFilesAnalyzed: True\n",
+      "comment":"## Package Information\nPackageName: Package B\nSPDXID: SPDXRef-Package-B\nPackageDownloadLocation: https://download.com\nFilesAnalyzed: true\n",
       "packageName":"Package B",
       "copyright":"None",
       "licenseName":"None",
@@ -82,7 +82,7 @@
         "name":"SPDX-Package",
         "documentConfidence":0
       },
-      "comment":"## Package Information\nPackageName: Package C\nSPDXID: SPDXRef-Package-C\nPackageDownloadLocation: https://download.com\nFilesAnalyzed: True\n",
+      "comment":"## Package Information\nPackageName: Package C\nSPDXID: SPDXRef-Package-C\nPackageDownloadLocation: https://download.com\nFilesAnalyzed: true\n",
       "packageName":"Package C",
       "copyright":"None",
       "licenseName":"None",


### PR DESCRIPTION
This commit replaces the failing dependabot PR #95 and fixes the test. According to the SPDX specification tag-value values are case-sensitive, this was not true for the test file, failed the validation and is fixed now.