### PR TITLE
chore: remove date from copyright header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 [project]

--- a/src/opossum_lib/attribution_generation.py
+++ b/src/opossum_lib/attribution_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from io import StringIO

--- a/src/opossum_lib/cli.py
+++ b/src/opossum_lib/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/opossum_lib/constants.py
+++ b/src/opossum_lib/constants.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 PURL = "purl"

--- a/src/opossum_lib/file_generation.py
+++ b/src/opossum_lib/file_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/src/opossum_lib/graph_generation.py
+++ b/src/opossum_lib/graph_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/opossum_lib/helper_methods.py
+++ b/src/opossum_lib/helper_methods.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any

--- a/src/opossum_lib/merger.py
+++ b/src/opossum_lib/merger.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any

--- a/src/opossum_lib/opossum_file.py
+++ b/src/opossum_lib/opossum_file.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations

--- a/src/opossum_lib/tree_generation.py
+++ b/src/opossum_lib/tree_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/helper_methods.py
+++ b/tests/helper_methods.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/tests/test_attribution_creation.py
+++ b/tests/test_attribution_creation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_file_generation.py
+++ b/tests/test_file_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path

--- a/tests/test_graph_generation.py
+++ b/tests/test_graph_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path

--- a/tests/test_helper_methods.py
+++ b/tests/test_helper_methods.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from unittest import mock

--- a/tests/test_opossum_file.py
+++ b/tests/test_opossum_file.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tests/test_tree_generation.py
+++ b/tests/test_tree_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TNG Technology Consulting GmbH <https://www.tngtech.com>
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime


### PR DESCRIPTION
Remove date from copyright headers so they don't need to be kept up-to-date.