### PR TITLE
feat: new cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,19 @@ uv sync
 ## Command-line usage
 
 ```bash
-Usage: uv run spdx2opossum [OPTIONS]
+Usage: uv run convert2opossum [OPTIONS]
 
-  CLI-tool for converting SPDX documents to Opossum documents.
+  CLI-tool for converting and merging various documents to Opossum documents.
+  Currently supported input formats:
+
+    - SPDX
 
 Options:
-  -i, --infile PATH   The file containing the document to be converted.
-                      [required]
+  -spdx PATH          SPDX files used as input.
   -o, --outfile TEXT  The file path to write the generated opossum document
                       to. The generated file will be an opossum file, if the
                       specified file path doesn't match this file extension
-                      ".opossum" will be appended.
+                      ".opossum" will be appended.  [default: output.opossum]
   --help              Show this message and exit.
 
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  generate  CLI-tool for converting and merging various documents to...
+  generate  Generate an Opossum file from various other file formats.
 ```
 
 ### `generate`
@@ -47,17 +47,16 @@ Commands:
 ```bash
 Usage: uv run opossum-file generate [OPTIONS]
 
-  CLI-tool for converting and merging various documents to Opossum documents.
-  Currently supported input formats:
+  Generate an Opossum file from various other file formats.
 
+  Currently supported input formats:
     - SPDX
 
 Options:
-  -spdx PATH          SPDX files used as input.
+  --spdx PATH         SPDX files used as input.
   -o, --outfile TEXT  The file path to write the generated opossum document
-                      to. The generated file will be an opossum file. If the
-                      specified file path doesn't match this file, extension
-                      ".opossum" will be appended.  [default: output.opossum]
+                      to. If appropriate, the extension ".opossum" will be
+                      appended.  [default: output.opossum]
   --help              Show this message and exit.
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,9 +31,21 @@ uv sync
 # How to use
 
 ## Command-line usage
+The CLI uses subcommands. The main command just displays all available subcommands
+```bash
+Usage: uv run opossum-file [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  generate  CLI-tool for converting and merging various documents to...
+```
+
+### `generate`
 
 ```bash
-Usage: uv run convert2opossum [OPTIONS]
+Usage: uv run opossum-file generate [OPTIONS]
 
   CLI-tool for converting and merging various documents to Opossum documents.
   Currently supported input formats:
@@ -43,8 +55,8 @@ Usage: uv run convert2opossum [OPTIONS]
 Options:
   -spdx PATH          SPDX files used as input.
   -o, --outfile TEXT  The file path to write the generated opossum document
-                      to. The generated file will be an opossum file, if the
-                      specified file path doesn't match this file extension
+                      to. The generated file will be an opossum file. If the
+                      specified file path doesn't match this file, extension
                       ".opossum" will be appended.  [default: output.opossum]
   --help              Show this message and exit.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 Repository = "https://github.com/opossum-tool/opossum.lib.py"
 
 [project.scripts]
-spdx2opossum = "opossum_lib.cli:spdx2opossum"
+opossum-file = "opossum_lib.cli:opossum_file"
 
 [dependency-groups]
 test = ["pytest>=8.3.4,<9"]

--- a/src/opossum_lib/cli.py
+++ b/src/opossum_lib/cli.py
@@ -27,7 +27,7 @@ def opossum_file() -> None:
 
 @opossum_file.command()
 @click.option(
-    "-spdx",
+    "--spdx",
     help="SPDX files used as input.",
     multiple=True,
     type=click.Path(exists=True),
@@ -37,15 +37,15 @@ def opossum_file() -> None:
     "-o",
     default="output.opossum",
     show_default=True,
-    help="The file path to write the generated opossum document to. The generated file "
-    "will be an opossum file. If the specified file path doesn't match this file, "
-    'extension ".opossum" will be appended.',
+    help="The file path to write the generated opossum document to. "
+    'If appropriate, the extension ".opossum" will be appended.',
 )
 def generate(spdx: list[str], outfile: str) -> None:
     """
-    CLI-tool for converting and merging various documents to Opossum documents.
-    Currently supported input formats:
+    Generate an Opossum file from various other file formats.
 
+    \b
+    Currently supported input formats:
       - SPDX
     """
     if len(spdx) == 0:

--- a/src/opossum_lib/cli.py
+++ b/src/opossum_lib/cli.py
@@ -20,12 +20,16 @@ from opossum_lib.graph_generation import generate_graph_from_spdx
 from opossum_lib.tree_generation import generate_tree_from_graph
 
 
-@click.command()
+@click.group()
+def opossum_file() -> None:
+    pass
+
+
+@opossum_file.command()
 @click.option(
-    "--infile",
-    "-i",
-    help="The file containing the document to be converted.",
-    required=True,
+    "-spdx",
+    help="SPDX files used as input.",
+    multiple=True,
     type=click.Path(exists=True),
 )
 @click.option(
@@ -34,15 +38,26 @@ from opossum_lib.tree_generation import generate_tree_from_graph
     default="output.opossum",
     show_default=True,
     help="The file path to write the generated opossum document to. The generated file "
-    "will be an opossum file, if the specified file path doesn't match this file "
+    "will be an opossum file. If the specified file path doesn't match this file, "
     'extension ".opossum" will be appended.',
 )
-def spdx2opossum(infile: str, outfile: str) -> None:
+def generate(spdx: list[str], outfile: str) -> None:
     """
-    CLI-tool for converting SPDX documents to Opossum documents.
+    CLI-tool for converting and merging various documents to Opossum documents.
+    Currently supported input formats:
+
+      - SPDX
     """
+    if len(spdx) == 0:
+        logging.warning("No input provided. Exiting.")
+        sys.exit(1)
+    if len(spdx) > 1:
+        logging.error("Merging of multiple SPDX files not yet supported!")
+        sys.exit(1)
+
+    the_spdx_file = spdx[0]
     try:
-        document: SpdxDocument = parse_file(infile)
+        document: SpdxDocument = parse_file(the_spdx_file)
 
     except SPDXParsingError as err:
         log_string = "\n".join(
@@ -73,4 +88,4 @@ def spdx2opossum(infile: str, outfile: str) -> None:
 
 
 if __name__ == "__main__":
-    spdx2opossum()
+    opossum_file()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,20 +10,20 @@ from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
 from spdx_tools.spdx.writer.write_anything import write_file
 
-from opossum_lib.cli import spdx2opossum
+from opossum_lib.cli import generate
 from tests.helper_methods import _create_minimal_document
 
 
-@pytest.mark.parametrize("options", [("--infile", "--outfile"), ("-i", "-o")])
-def test_cli_with_system_exit_code_0(tmp_path: Path, options: tuple[str, str]) -> None:
+@pytest.mark.parametrize("options", ["--outfile", "-o"])
+def test_cli_with_system_exit_code_0(tmp_path: Path, options: str) -> None:
     runner = CliRunner()
 
     result = runner.invoke(
-        spdx2opossum,
+        generate,
         [
-            options[0],
+            "-spdx",
             str(Path(__file__).resolve().parent / "data" / "SPDX.spdx"),
-            options[1],
+            options,
             str(tmp_path / "output"),
         ],
     )
@@ -54,8 +54,8 @@ def test_cli_no_output_file_provided() -> None:
         file_path = "input.spdx.json"
         create_valid_spdx_document(file_path)
         result = runner.invoke(
-            spdx2opossum,
-            "-i" + file_path,
+            generate,
+            "-spdx " + file_path,
         )
 
         assert result.exit_code == 0
@@ -72,8 +72,8 @@ def test_cli_warning_if_outfile_already_exists(caplog: LogCaptureFixture) -> Non
         with open("output.opossum", "w") as f:
             f.write("")
         result = runner.invoke(
-            spdx2opossum,
-            "-i" + file_path + " -o output.opossum",
+            generate,
+            "-spdx " + file_path + " -o output.opossum",
         )
 
     assert result.exit_code == 0
@@ -86,7 +86,7 @@ def test_cli_with_system_exit_code_1() -> None:
     with runner.isolated_filesystem():
         with open("invalid_spdx.spdx", "w") as f:
             f.write("SPDXID: SPDXRef-DOCUMENT")
-        result = runner.invoke(spdx2opossum, "-i invalid_spdx.spdx -o invalid")
+        result = runner.invoke(generate, "-spdx invalid_spdx.spdx -o invalid")
 
     assert result.exit_code == 1
 
@@ -95,13 +95,41 @@ def test_cli_with_invalid_document(caplog: LogCaptureFixture) -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():
         create_invalid_spdx_document("invalid_spdx.spdx")
-        result = runner.invoke(spdx2opossum, "-i invalid_spdx.spdx -o invalid")
+        result = runner.invoke(generate, "-spdx invalid_spdx.spdx -o invalid")
 
     assert result.output == ""
     assert caplog.messages == [
         "The given SPDX document is not valid, this might cause issues with "
         "the conversion."
     ]
+
+
+def test_cli_with_multiple_documents(caplog: LogCaptureFixture) -> None:
+    runner = CliRunner()
+    path_to_spdx = str(Path(__file__).resolve().parent / "data" / "SPDX.spdx")
+
+    result = runner.invoke(
+        generate,
+        ["-spdx", path_to_spdx, "-spdx", path_to_spdx],
+    )
+    assert result.exit_code == 1
+
+    assert caplog.messages == ["Merging of multiple SPDX files not yet supported!"]
+
+
+def test_cli_without_inputs(caplog: LogCaptureFixture) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        generate,
+        [
+            "-o",
+            "output.opossum",
+        ],
+    )
+    assert result.exit_code == 1
+
+    assert caplog.messages == ["No input provided. Exiting."]
 
 
 def create_invalid_spdx_document(file_path: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_with_system_exit_code_0(tmp_path: Path, options: str) -> None:
     result = runner.invoke(
         generate,
         [
-            "-spdx",
+            "--spdx",
             str(Path(__file__).resolve().parent / "data" / "SPDX.spdx"),
             options,
             str(tmp_path / "output"),
@@ -55,7 +55,7 @@ def test_cli_no_output_file_provided() -> None:
         create_valid_spdx_document(file_path)
         result = runner.invoke(
             generate,
-            "-spdx " + file_path,
+            "--spdx " + file_path,
         )
 
         assert result.exit_code == 0
@@ -73,7 +73,7 @@ def test_cli_warning_if_outfile_already_exists(caplog: LogCaptureFixture) -> Non
             f.write("")
         result = runner.invoke(
             generate,
-            "-spdx " + file_path + " -o output.opossum",
+            "--spdx " + file_path + " -o output.opossum",
         )
 
     assert result.exit_code == 0
@@ -86,7 +86,7 @@ def test_cli_with_system_exit_code_1() -> None:
     with runner.isolated_filesystem():
         with open("invalid_spdx.spdx", "w") as f:
             f.write("SPDXID: SPDXRef-DOCUMENT")
-        result = runner.invoke(generate, "-spdx invalid_spdx.spdx -o invalid")
+        result = runner.invoke(generate, "--spdx invalid_spdx.spdx -o invalid")
 
     assert result.exit_code == 1
 
@@ -95,7 +95,7 @@ def test_cli_with_invalid_document(caplog: LogCaptureFixture) -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():
         create_invalid_spdx_document("invalid_spdx.spdx")
-        result = runner.invoke(generate, "-spdx invalid_spdx.spdx -o invalid")
+        result = runner.invoke(generate, "--spdx invalid_spdx.spdx -o invalid")
 
     assert result.output == ""
     assert caplog.messages == [
@@ -110,7 +110,7 @@ def test_cli_with_multiple_documents(caplog: LogCaptureFixture) -> None:
 
     result = runner.invoke(
         generate,
-        ["-spdx", path_to_spdx, "-spdx", path_to_spdx],
+        ["--spdx", path_to_spdx, "--spdx", path_to_spdx],
     )
     assert result.exit_code == 1
 


### PR DESCRIPTION
### Summary of changes

Implements the proposed CLI from #156.

### Context and reason for change

The current CLI is limited to a single SPDX input file. In the future, we want to allow for multiple input files (that then are merged into a single opossum file) and also allow for different input formats such as CycloneDX. To this end the new CLI has options for each allowed input file type (currently only SPDX) and these options can be repeated if multiple files should be input.

As of now neither merging nor other input formats are implemented, so specifying more then 1 SPDX file just raises an error. Failing to provide inputs, also results in an error.

To reflect this new intended functionality the name of the command is changed to `convert2opossum`.

### How can the changes be tested

Try one of these commands:
Should work and create a file `output.opossum`
```
uv run opossum-file
uv run opossum-file generate --help
uv run opossum-file generate --spdx tests/data/SPDX.spdx
```
Should error/warn and not create a file:
```
uv run opossum-file generate
uv run opossum-file generate --spdx tests/data/SPDX.spdx --spdx tests/data/SPDX.spdx
```

Fixes #156 