### PR TITLE
refactor: migrate opossum_file to pydantic basemodel

### DIFF
--- a/src/opossum_lib/opossum/merger.py
+++ b/src/opossum_lib/opossum/merger.py
@@ -88,7 +88,7 @@ def expand_opossum_package_identifier(
 
 
 def _merge_resources(resources: list[Resource]) -> Resource:
-    merged_resource = Resource(ResourceType.TOP_LEVEL)
+    merged_resource = Resource(type=ResourceType.TOP_LEVEL)
     for resource in resources:
         for path in resource.get_paths_of_all_leaf_nodes_with_types():
             merged_resource = merged_resource.add_path(path)

--- a/src/opossum_lib/opossum/opossum_file.py
+++ b/src/opossum_lib/opossum/opossum_file.py
@@ -47,8 +47,8 @@ class FrequentLicense(BaseModel):
     defaultText: str
 
 
-@dataclass(frozen=True)
-class SourceInfo:
+class SourceInfo(BaseModel):
+    model_config = ConfigDict(frozen=True)
     name: str
     documentConfidence: int | float | None = 0
     additionalName: str | None = None

--- a/src/opossum_lib/opossum/opossum_file.py
+++ b/src/opossum_lib/opossum/opossum_file.py
@@ -9,7 +9,6 @@ from enum import Enum, auto
 from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, model_serializer
-from pydantic.dataclasses import dataclass
 
 type OpossumPackageIdentifier = str
 type ResourcePath = str
@@ -182,8 +181,8 @@ class Resource(BaseModel):
         return self.to_dict()
 
 
-@dataclass(frozen=True)
-class ExternalAttributionSource:
+class ExternalAttributionSource(BaseModel):
+    model_config = ConfigDict(frozen=True)
     name: str
     priority: int
     isRelevantForPreferred: bool | None = None

--- a/src/opossum_lib/opossum/opossum_file.py
+++ b/src/opossum_lib/opossum/opossum_file.py
@@ -54,8 +54,8 @@ class SourceInfo(BaseModel):
     additionalName: str | None = None
 
 
-@dataclass(frozen=True)
-class OpossumPackage:
+class OpossumPackage(BaseModel):
+    model_config = ConfigDict(frozen=True)
     source: SourceInfo
     attributionConfidence: int | None = None
     comment: str | None = None

--- a/src/opossum_lib/opossum/opossum_file.py
+++ b/src/opossum_lib/opossum/opossum_file.py
@@ -16,8 +16,8 @@ type ResourcePath = str
 type ResourceInFile = dict[str, ResourceInFile] | int
 
 
-@dataclass(frozen=True)
-class OpossumInformation:
+class OpossumInformation(BaseModel):
+    model_config = ConfigDict(frozen=True)
     metadata: Metadata
     resources: ResourceInFile
     externalAttributions: dict[OpossumPackageIdentifier, OpossumPackage]

--- a/src/opossum_lib/opossum/opossum_file.py
+++ b/src/opossum_lib/opossum/opossum_file.py
@@ -95,8 +95,8 @@ class ResourceType(Enum):
     OTHER = auto()
 
 
-@dataclass(frozen=True)
-class Resource:
+class Resource(BaseModel):
+    model_config = ConfigDict(frozen=True)
     type: ResourceType
     children: dict[str, Resource] = field(default_factory=dict)
 
@@ -138,7 +138,7 @@ class Resource:
             )
 
         else:
-            resource = Resource(ResourceType.TOP_LEVEL)
+            resource = Resource(type=ResourceType.TOP_LEVEL)
             paths_in_resource.remove(path_to_element_to_drop)
             paths_in_resource.append(path_to_element_to_drop[:-1])
 
@@ -200,7 +200,7 @@ def _build_resource_tree(resource: ResourceInFile) -> Resource:
 
 
 def convert_resource_in_file_to_resource(resource: ResourceInFile) -> Resource:
-    root_node = Resource(ResourceType.TOP_LEVEL)
+    root_node = Resource(type=ResourceType.TOP_LEVEL)
 
     if isinstance(resource, dict):
         dict_resource = cast(dict[str, ResourceInFile], resource)

--- a/src/opossum_lib/scancode/resource_tree.py
+++ b/src/opossum_lib/scancode/resource_tree.py
@@ -70,7 +70,7 @@ def get_attribution_info(file: File) -> list[OpossumPackage]:
     if file.type == FileType.DIRECTORY:
         return []
     copyright = "\n".join(c.copyright for c in file.copyrights)
-    source_info = SourceInfo(SCANCODE_SOURCE_NAME)
+    source_info = SourceInfo(name=SCANCODE_SOURCE_NAME)
 
     attribution_infos = []
     for license_detection in file.license_detections:

--- a/src/opossum_lib/scancode/resource_tree.py
+++ b/src/opossum_lib/scancode/resource_tree.py
@@ -79,7 +79,7 @@ def get_attribution_info(file: File) -> list[OpossumPackage]:
         attribution_confidence = int(max_score)
 
         package = OpossumPackage(
-            source_info,
+            source=source_info,
             licenseName=license_name,
             attributionConfidence=attribution_confidence,
             copyright=copyright,

--- a/src/opossum_lib/spdx/attribution_generation.py
+++ b/src/opossum_lib/spdx/attribution_generation.py
@@ -31,7 +31,7 @@ def _get_purl(package: Package) -> str | None:
 def create_package_attribution(package: Package) -> OpossumPackage:
     package_data = StringIO()
     write_package(package, package_data)
-    source = SourceInfo(SPDX_PACKAGE_IDENTIFIER)
+    source = SourceInfo(name=SPDX_PACKAGE_IDENTIFIER)
     package_attribution = OpossumPackage(
         source=source,
         packageName=package.name,
@@ -49,7 +49,7 @@ def create_package_attribution(package: Package) -> OpossumPackage:
 def create_file_attribution(file: File) -> OpossumPackage:
     file_data = StringIO()
     write_file(file, file_data)
-    source = SourceInfo(SPDX_FILE_IDENTIFIER)
+    source = SourceInfo(name=SPDX_FILE_IDENTIFIER)
     file_attribution = OpossumPackage(
         source=source,
         packageName=file.name.split("/")[-1],
@@ -63,7 +63,7 @@ def create_file_attribution(file: File) -> OpossumPackage:
 def create_snippet_attribution(snippet: Snippet) -> OpossumPackage:
     snippet_data = StringIO()
     write_snippet(snippet, snippet_data)
-    source = SourceInfo(SPDX_SNIPPET_IDENTIFIER)
+    source = SourceInfo(name=SPDX_SNIPPET_IDENTIFIER)
     snippet_attribution = OpossumPackage(
         source=source,
         packageName=snippet.name,
@@ -80,7 +80,7 @@ def create_document_attribution(
 ) -> OpossumPackage:
     creation_info_data = StringIO()
     write_creation_info(creation_info, creation_info_data)
-    source = SourceInfo(creation_info.spdx_id)
+    source = SourceInfo(name=creation_info.spdx_id)
     document_attribution = OpossumPackage(
         source=source,
         packageName=creation_info.name,

--- a/src/opossum_lib/spdx/convert_to_opossum.py
+++ b/src/opossum_lib/spdx/convert_to_opossum.py
@@ -80,12 +80,14 @@ def convert_tree_to_opossum_information(tree: DiGraph) -> OpossumInformation:
     external_attributions: dict[str, OpossumPackage] = dict()
     attribution_breakpoints = []
     external_attribution_sources = {
-        SPDX_FILE_IDENTIFIER: ExternalAttributionSource(SPDX_FILE_IDENTIFIER, 500),
+        SPDX_FILE_IDENTIFIER: ExternalAttributionSource(
+            name=SPDX_FILE_IDENTIFIER, priority=500
+        ),
         SPDX_PACKAGE_IDENTIFIER: ExternalAttributionSource(
-            SPDX_PACKAGE_IDENTIFIER, 500
+            name=SPDX_PACKAGE_IDENTIFIER, priority=500
         ),
         SPDX_SNIPPET_IDENTIFIER: ExternalAttributionSource(
-            SPDX_SNIPPET_IDENTIFIER, 500
+            name=SPDX_SNIPPET_IDENTIFIER, priority=500
         ),
     }
 

--- a/src/opossum_lib/spdx/convert_to_opossum.py
+++ b/src/opossum_lib/spdx/convert_to_opossum.py
@@ -164,7 +164,7 @@ def create_attribution_and_link_with_resource(
 
     else:
         external_attributions[node] = OpossumPackage(
-            source=SourceInfo(tree.nodes[node]["label"])
+            source=SourceInfo(name=tree.nodes[node]["label"])
         )
         resources_to_attributions[file_path] = [node]
 

--- a/tests/test_opossum/test_merge.py
+++ b/tests/test_opossum/test_merge.py
@@ -176,15 +176,15 @@ def test_merge_dicts_without_duplicates_type_error(
     source_info: SourceInfo,
 ) -> None:
     dicts = [
-        {"A": OpossumPackage(source_info, comment="test package 1")},
-        {"A": OpossumPackage(source_info, comment="test package 2")},
+        {"A": OpossumPackage(source=source_info, comment="test package 1")},
+        {"A": OpossumPackage(source=source_info, comment="test package 2")},
     ]
     with pytest.raises(TypeError):
         _merge_dicts_without_duplicates(dicts)
 
 
 def test_expand_opossum_package_identifier() -> None:
-    opossum_package = OpossumPackage(SourceInfo(name="source-info"))
+    opossum_package = OpossumPackage(source=SourceInfo(name="source-info"))
     opossum_information_expanded = expand_opossum_package_identifier(
         OpossumInformation(
             Metadata(

--- a/tests/test_opossum/test_merge.py
+++ b/tests/test_opossum/test_merge.py
@@ -25,7 +25,7 @@ from opossum_lib.opossum.opossum_file import (
 
 
 def test_merge_opossum_information() -> None:
-    opossum_package = OpossumPackage(source=SourceInfo("source"))
+    opossum_package = OpossumPackage(source=SourceInfo(name="source"))
     opossum_information = OpossumInformation(
         Metadata(
             projectId="project-id",
@@ -184,7 +184,7 @@ def test_merge_dicts_without_duplicates_type_error(
 
 
 def test_expand_opossum_package_identifier() -> None:
-    opossum_package = OpossumPackage(SourceInfo("source-info"))
+    opossum_package = OpossumPackage(SourceInfo(name="source-info"))
     opossum_information_expanded = expand_opossum_package_identifier(
         OpossumInformation(
             Metadata(

--- a/tests/test_opossum/test_merge.py
+++ b/tests/test_opossum/test_merge.py
@@ -27,25 +27,25 @@ from opossum_lib.opossum.opossum_file import (
 def test_merge_opossum_information() -> None:
     opossum_package = OpossumPackage(source=SourceInfo(name="source"))
     opossum_information = OpossumInformation(
-        Metadata(
+        metadata=Metadata(
             projectId="project-id",
             fileCreationDate="30-05-2023",
             projectTitle="test data",
         ),
-        {"A": {"B": {}}},
-        {"SPDXRef-Package": opossum_package},
-        {"/A/B/": ["SPDXRef-Package"]},
+        resources={"A": {"B": {}}},
+        externalAttributions={"SPDXRef-Package": opossum_package},
+        resourcesToAttributions={"/A/B/": ["SPDXRef-Package"]},
     )
 
     opossum_information_2 = OpossumInformation(
-        Metadata(
+        metadata=Metadata(
             projectId="test-data-id",
             fileCreationDate="29-05-2023",
             projectTitle="second test data",
         ),
-        {"A": {"D": {"C": 1}}},
-        {"SPDXRef-File": opossum_package},
-        {"/A/D/C": ["SPDXRef-File"]},
+        resources={"A": {"D": {"C": 1}}},
+        externalAttributions={"SPDXRef-File": opossum_package},
+        resourcesToAttributions={"/A/D/C": ["SPDXRef-File"]},
     )
 
     merged_information = merge_opossum_information(
@@ -189,7 +189,7 @@ def test_expand_opossum_package_identifier() -> None:
     opossum_package = OpossumPackage(source=SourceInfo(name="source-info"))
     opossum_information_expanded = expand_opossum_package_identifier(
         OpossumInformation(
-            Metadata(
+            metadata=Metadata(
                 projectId="project-id",
                 fileCreationDate="2022-03-02",
                 projectTitle="project title",

--- a/tests/test_opossum/test_merge.py
+++ b/tests/test_opossum/test_merge.py
@@ -80,7 +80,7 @@ def test_merge_resources() -> None:
         [("A", ResourceType.FOLDER), ("D", ResourceType.FILE)],
     ]
 
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
     for path in list_of_paths_with_resource_types:
         resource = resource.add_path(path)
 
@@ -98,7 +98,7 @@ def test_merge_resources() -> None:
             ("E", ResourceType.FOLDER),
         ],
     ]
-    resource2 = Resource(ResourceType.TOP_LEVEL)
+    resource2 = Resource(type=ResourceType.TOP_LEVEL)
     for path in list_of_paths_with_resource_type:
         resource2 = resource2.add_path(path)
 
@@ -106,22 +106,24 @@ def test_merge_resources() -> None:
     merged_resource = _merge_resources(resources)
 
     assert merged_resource == Resource(
-        ResourceType.TOP_LEVEL,
-        {
+        type=ResourceType.TOP_LEVEL,
+        children={
             "A": Resource(
-                ResourceType.FOLDER,
-                {
+                type=ResourceType.FOLDER,
+                children={
                     "B": Resource(
-                        ResourceType.FOLDER, {"C": Resource(ResourceType.FILE, {})}
+                        type=ResourceType.FOLDER,
+                        children={"C": Resource(type=ResourceType.FILE)},
                     ),
-                    "D": Resource(ResourceType.FILE, {}),
+                    "D": Resource(type=ResourceType.FILE),
                 },
             ),
             "C": Resource(
-                ResourceType.FOLDER,
-                {
+                type=ResourceType.FOLDER,
+                children={
                     "D": Resource(
-                        ResourceType.FOLDER, {"E": Resource(ResourceType.FOLDER, {})}
+                        type=ResourceType.FOLDER,
+                        children={"E": Resource(type=ResourceType.FOLDER)},
                     )
                 },
             ),

--- a/tests/test_opossum/test_opossum_file.py
+++ b/tests/test_opossum/test_opossum_file.py
@@ -22,7 +22,7 @@ def test_resource_to_dict_with_file_as_leaf() -> None:
         [("A", ResourceType.FOLDER), ("B", ResourceType.FILE)],
         [("A", ResourceType.FOLDER), ("D", ResourceType.FILE)],
     ]
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
         resource = resource.add_path(path)
@@ -41,7 +41,7 @@ def test_resource_to_dict_with_package_as_leaf() -> None:
         [("A", ResourceType.FOLDER), ("B", ResourceType.FILE)],
         [("A", ResourceType.FOLDER), ("D", ResourceType.FOLDER)],
     ]
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
         resource = resource.add_path(path)
@@ -66,7 +66,7 @@ def test_resource_get_path() -> None:
             ("F", ResourceType.OTHER),
         ],
     ]
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
 
     for path in list_of_paths:
         resource = resource.add_path(path)
@@ -92,7 +92,7 @@ def test_resource_get_path() -> None:
 def test_resource_add_path_throws_err_if_leaf_element_exists_with_different_type() -> (
     None
 ):
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
     resource = resource.add_path(
         [
             ("A", ResourceType.FOLDER),
@@ -112,7 +112,7 @@ def test_resource_add_path_throws_err_if_leaf_element_exists_with_different_type
 
 
 def test_resource_add_path_throws_err_if_element_exists_with_different_type() -> None:
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
     resource = resource.add_path(
         [
             ("A", ResourceType.FOLDER),
@@ -133,7 +133,7 @@ def test_resource_add_path_throws_err_if_element_exists_with_different_type() ->
 
 
 def test_resource_drop_element_error() -> None:
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
     resource = resource.add_path(
         [
             ("A", ResourceType.FOLDER),
@@ -154,7 +154,7 @@ def test_resource_drop_element_error() -> None:
 
 
 def test_resource_drop_element_error_not_leaf() -> None:
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
     resource = resource.add_path(
         [
             ("A", ResourceType.FOLDER),
@@ -175,7 +175,7 @@ def test_resource_drop_element_error_not_leaf() -> None:
 
 
 def test_resource_drop_element() -> None:
-    resource = Resource(ResourceType.TOP_LEVEL)
+    resource = Resource(type=ResourceType.TOP_LEVEL)
     resource = resource.add_path(
         [
             ("A", ResourceType.FOLDER),

--- a/tests/test_scancode/test_resource_tree.py
+++ b/tests/test_scancode/test_resource_tree.py
@@ -216,13 +216,13 @@ def test_get_attribution_info_file_multiple() -> None:
     )
     attributions = get_attribution_info(file)
     expected1 = OpossumPackage(
-        source=SourceInfo(SCANCODE_SOURCE_NAME),
+        source=SourceInfo(name=SCANCODE_SOURCE_NAME),
         licenseName="Apache-2.0",
         copyright="Me\nMyself\nI",
         attributionConfidence=95,
     )
     expected2 = OpossumPackage(
-        source=SourceInfo(SCANCODE_SOURCE_NAME),
+        source=SourceInfo(name=SCANCODE_SOURCE_NAME),
         licenseName="MIT",
         copyright="Me\nMyself\nI",
         attributionConfidence=50,

--- a/tests/test_spdx/test_attribution_creation.py
+++ b/tests/test_spdx/test_attribution_creation.py
@@ -55,7 +55,7 @@ def test_create_package_attribution() -> None:
     package_attribution = create_package_attribution(package)
 
     assert package_attribution == OpossumPackage(
-        source=SourceInfo(SPDX_PACKAGE_IDENTIFIER),
+        source=SourceInfo(name=SPDX_PACKAGE_IDENTIFIER),
         comment=package_data.getvalue(),
         packageName=package.name,
         packageVersion=package.version,
@@ -80,7 +80,7 @@ def test_create_file_attribution() -> None:
     file_attribution = create_file_attribution(file)
 
     assert file_attribution == OpossumPackage(
-        source=SourceInfo(SPDX_FILE_IDENTIFIER),
+        source=SourceInfo(name=SPDX_FILE_IDENTIFIER),
         comment=file_data.getvalue(),
         packageName=file.name,
         copyright=str(file.copyright_text),
@@ -103,7 +103,7 @@ def test_create_snippet_attribution() -> None:
     snippet_attribution = create_snippet_attribution(snippet)
 
     assert snippet_attribution == OpossumPackage(
-        source=SourceInfo(SPDX_SNIPPET_IDENTIFIER),
+        source=SourceInfo(name=SPDX_SNIPPET_IDENTIFIER),
         comment=snippet_data.getvalue(),
         packageName=snippet.name,
         licenseName=str(snippet.license_concluded),
@@ -125,7 +125,7 @@ def test_create_document_attribution() -> None:
     document_attribution = create_document_attribution(creation_info)
 
     assert document_attribution == OpossumPackage(
-        source=SourceInfo(DOCUMENT_SPDX_ID),
+        source=SourceInfo(name=DOCUMENT_SPDX_ID),
         packageName=creation_info.name,
         licenseName=creation_info.data_license,
         comment=creation_info_data.getvalue(),

--- a/tests/test_spdx/test_extract_opossum_information_from_spdx.py
+++ b/tests/test_spdx/test_extract_opossum_information_from_spdx.py
@@ -74,12 +74,14 @@ def test_different_paths_graph() -> None:
     )
 
     assert opossum_information.externalAttributionSources == {
-        SPDX_FILE_IDENTIFIER: ExternalAttributionSource(SPDX_FILE_IDENTIFIER, 500),
+        SPDX_FILE_IDENTIFIER: ExternalAttributionSource(
+            name=SPDX_FILE_IDENTIFIER, priority=500
+        ),
         SPDX_PACKAGE_IDENTIFIER: ExternalAttributionSource(
-            SPDX_PACKAGE_IDENTIFIER, 500
+            name=SPDX_PACKAGE_IDENTIFIER, priority=500
         ),
         SPDX_SNIPPET_IDENTIFIER: ExternalAttributionSource(
-            SPDX_SNIPPET_IDENTIFIER, 500
+            name=SPDX_SNIPPET_IDENTIFIER, priority=500
         ),
     }
 


### PR DESCRIPTION
## Summary of changes
* All classes in opossum_file.py that previously where annotated with `@dataclass` are now based on `pydantic.BaseModel` 
* All constructors of these classes where changed to keywords accordingly

## Context and reason for change
Prior to the introduction of pydantic, Python dataclasses were used. With the switch to validation by pydantic in #172  the path of lowest resistance was chosen which meant switching to pydantic.dataclasses. This PR now completes the migration to pydantic by converting these to `BaseModel`. Apart from being consistent, this enables a much more flexible configuration in the future like e.g. using snake_case for all fields while retaining the correct casing during serialization.