### PR TITLE
fix: preserve attributions on folders

### DIFF
--- a/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
@@ -194,11 +194,18 @@ def _convert_to_resource_tree(
     ) -> tuple[list[OpossumPackage], set[OpossumPackageIdentifierModel]]:
         attributions = []
         attribution_ids: list[str] = []
-        if current_path_as_string in resources_to_attributions:
-            attribution_ids = resources_to_attributions[current_path_as_string]
-            attributions = [
-                _convert_package(external_attributions[id]) for id in attribution_ids
-            ]
+        possible_keys = [
+            current_path_as_string.rstrip("/"),
+            current_path_as_string.rstrip("/") + "/",
+        ]
+        for path_key in possible_keys:
+            if path_key in resources_to_attributions:
+                attribution_ids = resources_to_attributions[path_key]
+                attributions = [
+                    _convert_package(external_attributions[id])
+                    for id in attribution_ids
+                ]
+                break
         return attributions, set(attribution_ids)
 
     root_path = PurePath("")

--- a/tests/input_formats/opossum/services/test_conversion_roundtrip.py
+++ b/tests/input_formats/opossum/services/test_conversion_roundtrip.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from copy import deepcopy
 
+from opossum_lib.core.entities.resource import ResourceType
 from opossum_lib.input_formats.opossum.services.convert_to_opossum import (
     convert_to_opossum,
 )
@@ -28,6 +29,33 @@ class TestConversionRoundtrip:
             opossum_file_faker.external_attributions()
         )
         TestConversionRoundtrip._check_round_trip(start_file_content)
+
+    def test_folder_attributions_roundtrip(
+        self, opossum_file_faker: OpossumFileFaker
+    ) -> None:
+        attribution_id = "folder-attribution"
+        package = opossum_file_faker.opossum_package(origin_ids=["folder-origin"])
+        start_file_content = OpossumFileModel(
+            input_file=opossum_file_faker.opossum_file_information(
+                resources={"folder": {"file.txt": 1}},
+                external_attributions={attribution_id: package},
+                resources_to_attributions={"/folder/": [attribution_id]},
+            )
+        )
+
+        result = convert_to_opossum(start_file_content)
+
+        folder_resource = result.scan_results.resources.children["folder"]
+        assert folder_resource.type == ResourceType.FOLDER
+        assert len(folder_resource.attributions) == 1
+        assert result.scan_results.attribution_to_id[
+            folder_resource.attributions[0]
+        ] == (attribution_id)
+
+        roundtrip = result.to_opossum_file_model()
+        assert roundtrip.input_file.resources_to_attributions == {
+            "/folder": [attribution_id]
+        }
 
     @staticmethod
     def _check_round_trip(start_file_content: OpossumFileModel) -> None:


### PR DESCRIPTION
# Issue
When reading an opssum file where folders have attributions, we drop them. This is caused by an incorrect path in the lookup of the attributions.

# Fix
Look up both variant of the path: With and without trailing slash.