### PR TITLE
fix: handle empty path tree correctly in scancode file faker

### DIFF
--- a/tests/input_formats/scancode/entities/generators/generate_files.py
+++ b/tests/input_formats/scancode/entities/generators/generate_files.py
@@ -81,7 +81,8 @@ class ScanCodeFileProvider(BaseProvider):
     def files(
         self, options: OptionsModel, path_tree: TempPathTree | None = None
     ) -> list[FileModel]:
-        path_tree = path_tree or self.generate_path_structure()
+        if path_tree is None:
+            path_tree = self.generate_path_structure()
 
         def process_path(current_path: str, path_tree: TempPathTree) -> list[FileModel]:
             files: list[FileModel] = []


### PR DESCRIPTION
## Summary

Fixes a flaky test in `TestScancodeIndividualOptions` (`test_full_root_path_option_gives_identical_result` and `test_strip_root_path_option_gives_identical_result`).

## Problem

The `files()` method in `generate_files.py` used a truthy check to decide whether to generate a new path structure:

```python
path_tree = path_tree or self.generate_path_structure()
```

When `generate_path_structure()` randomly produces an empty dict `{}` (zero files and zero folders at root level), the empty dict is **falsy** in Python. This causes the `or` to fall through to `self.generate_path_structure()`, generating a brand-new, different path tree.

In the flaky tests, the same `pathtree` is passed to `files()` twice with different options. When the pathtree happens to be empty, the second call silently discards it and generates a different one, leading to completely different resource paths and a failing assertion.

## Reproducing

Faker seed `1777891680` (from [CI run on PR #292](https://github.com/opossum-tool/opossum-file/actions/runs/25314758298/job/74209644771)) reproduces the issue reliably.

## Fix

Replace the truthy check with an explicit `None` check so that an explicitly-provided empty path tree is respected:

```python
if path_tree is None:
    path_tree = self.generate_path_structure()
```

## Test plan

- [x] All 68 tests pass
- [x] Lint passes
- [x] Previously failing tests now pass with the reproducing faker seed