### PR TITLE
fix: run CLI tests in isolated filesystem to avoid leftover output.opossum

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,8 @@ test_data_path = Path(__file__).resolve().parent / "data"
 
 def run_with_command_line_arguments(cmd_line_arguments: list[str]) -> Result:
     runner = CliRunner()
-    result = runner.invoke(generate, cmd_line_arguments)
+    with runner.isolated_filesystem():
+        result = runner.invoke(generate, cmd_line_arguments)
     return result
 
 


### PR DESCRIPTION
## Summary

CLI tests that relied on the default output path (`output.opossum`) wrote that file into the project root, leaving it behind after the test run.

## Fix

Wrap the `CliRunner.invoke` call in `isolated_filesystem()` so any generated files are created in a temp directory instead. This is consistent with how `test_cli_no_output_file_provided` already handles it.

## Test plan

- [x] All CLI tests pass
- [x] No `output.opossum` left in project root after running tests