### PR TITLE
Remove user-identifying paths from test fixtures

### DIFF
--- a/tests/data/dependency-check-report.json
+++ b/tests/data/dependency-check-report.json
@@ -60,7 +60,7 @@
     {
       "isVirtual": true,
       "fileName": "async:2.6.3",
-      "filePath": "/home/hellgartner/workspace/meta_oss/code/old-opossumUI/yarn.lock?async",
+      "filePath": "/home/user/workspace/meta_oss/code/old-opossumUI/yarn.lock?async",
       "projectReferences": [
         "yarn.lock: transitive"
       ],

--- a/tests/data/scancode_input.json
+++ b/tests/data/scancode_input.json
@@ -5,12 +5,12 @@
       "tool_version": "v32.3.0-20-g93ca65c34e",
       "options": {
         "input": [
-          "/home/hellgartner/workspace/meta_oss/code/OpossumUI/src/"
+          "/home/user/workspace/meta_oss/code/OpossumUI/src/"
         ],
         "--copyright": true,
         "--email": true,
         "--info": true,
-        "--json-pp": "/home/hellgartner/workspace/meta_oss/tasks/opossum_py_50_parse_scan_code_files/exampleFiles/opossum_src_pp.json",
+        "--json-pp": "/home/user/workspace/meta_oss/tasks/opossum_py_50_parse_scan_code_files/exampleFiles/opossum_src_pp.json",
         "--license": true,
         "--package": true,
         "--processes": "4",


### PR DESCRIPTION
## Summary
- Replace `/home/hellgartner/` with `/home/user/` in `tests/data/scancode_input.json` and `tests/data/dependency-check-report.json`
- Removes personal username from checked-in test fixture paths that were captured from the original author's machine
- No functional changes; test data structure and content remain identical