### PR TITLE
chore: remove unused mypy overrides for networkx and license_expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,6 @@ disallow_untyped_defs = true
 mypy_path = 'src:tests'
 plugins = ["pydantic.mypy"]
 
-[[tool.mypy.overrides]]
-module = ['networkx.*', 'license_expression.*']
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 


### PR DESCRIPTION
Removes the orphaned `[[tool.mypy.overrides]]` block for `networkx.*` and `license_expression.*` from `pyproject.toml`.

These leftovers came from commit `66f0245` ("feat: delete SPDX frontend", Jan 2025), which removed the `networkx` and `spdx-tools` dependencies but forgot to drop the corresponding `ignore_missing_imports` overrides. `license_expression` was a transitive dependency of `spdx-tools`. Neither module is imported anywhere in `src/` or `tests/`.

Verified with `uv run task verify` (lint, format, typecheck, 69 tests).