### PR TITLE
chore: convert pre-commit hooks to local uv-run hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,28 +2,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+  - repo: local
     hooks:
       - id: ruff
+        name: ruff
+        entry: uv run ruff check
+        language: system
+        types: [python]
+        pass_filenames: true
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
-    hooks:
+        name: ruff-format
+        entry: uv run ruff format --check
+        language: system
+        types: [python]
+        pass_filenames: true
       - id: mypy
-        language: python
-        additional_dependencies:
-          - "click>=8.4.2,<9"
-          - "packageurl-python>=0.17.6"
-          - "pydantic>=2.13.4"
-          - "faker>=40.28.1"
-          - "pytest>=9.1.1,<10"
-  - repo: https://github.com/hukkin/mdformat
-    rev: 1.0.0
-    hooks:
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+        args: ["src/", "tests/"]
       - id: mdformat
-        additional_dependencies: [mdformat-config, mdformat-gfm]
-  - repo: https://github.com/fsfe/reuse-tool
-    rev: v6.2.0
-    hooks:
+        name: mdformat
+        entry: uv run mdformat
+        language: system
+        types: [markdown]
+        pass_filenames: true
       - id: reuse
+        name: reuse
+        entry: uv run reuse lint
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
Replaces the four external pre-commit hooks (`ruff-pre-commit`, `mirrors-mypy`, `hukkin/mdformat`, `fsfe/reuse-tool`) with local hooks that invoke the tools via `uv run`.

## Why

Tool versions were duplicated: pinned in `.pre-commit-config.yaml` **and** declared in `pyproject.toml`'s dev group. Renovate bumped one side but not the other, causing drift — exactly what happened with mypy in #297, which required a manual follow-up to keep the dev dep in sync.

Making `pyproject.toml` the single source of truth eliminates this entire class of problem. The `additional_dependencies` blocks for mypy and mdformat are also no longer needed, since the hooks now run inside the project venv which already contains those packages and their plugins.

## Verification

```
uv run pre-commit run --all-files   → all 5 hooks passed
uv run task verify                  → lint + format + typecheck + 69 tests passed
```