### PR TITLE
chore: group pre-commit hooks with pip deps in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,34 @@
         "patch"
       ],
       "automerge": true
+    },
+    {
+      "groupName": "ruff",
+      "matchDepNames": [
+        "ruff",
+        "astral-sh/ruff-pre-commit"
+      ]
+    },
+    {
+      "groupName": "mypy",
+      "matchDepNames": [
+        "mypy",
+        "pre-commit/mirrors-mypy"
+      ]
+    },
+    {
+      "groupName": "mdformat",
+      "matchDepNames": [
+        "mdformat",
+        "hukkin/mdformat"
+      ]
+    },
+    {
+      "groupName": "reuse",
+      "matchDepNames": [
+        "reuse",
+        "fsfe/reuse-tool"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds `packageRules` to `renovate.json` that group each tool's pre-commit hook and pip dependency under a shared `groupName`, so Renovate bumps both in a single PR.

| Group | pre-commit hook (rev) | pip dep (pyproject.toml) |
|-------|----------------------|--------------------------|
| ruff  | `astral-sh/ruff-pre-commit` | `ruff` |
| mypy  | `pre-commit/mirrors-mypy`  | `mypy` |
| mdformat | `hukkin/mdformat`       | `mdformat` |
| reuse | `fsfe/reuse-tool`         | `reuse` |

## Why

Prevents version drift between `.pre-commit-config.yaml` and `pyproject.toml`. This is the issue seen in #297, where Renovate bumped the `mirrors-mypy` hook to v2 but left the `mypy` dev dependency at v1.20.2, requiring a manual follow-up (commit 11f9494).

With grouping, Renovate will open **one** PR per tool that updates both the hook rev and the pip constraint together.

## Trade-off vs alternatives

- **Local `uv run` hooks** (#305, closed): eliminates drift entirely but loses pre-commit's environment isolation and broke on a reviewer's machine.
- **`sync-with-uv`**: auto-rewrites revs from `uv.lock` on every commit; works but adds a new tool/dependency.
- **Renovate grouping (this PR)**: no new tooling, keeps isolation, fixes the root cause. The only caveat is eventual consistency between Renovate runs, which is acceptable given this repo's PR merge cadence.